### PR TITLE
feat: add localization and shell-aware 404

### DIFF
--- a/docs/design/favoritable.pen
+++ b/docs/design/favoritable.pen
@@ -2844,21 +2844,21 @@
           "id": "M7V0c",
           "x": 748,
           "y": 100,
-          "width": 236,
-          "height": "fit_content(216)",
+          "width": "fit_content(236)",
           "fill": "$surface-light",
           "cornerRadius": "$radius-3xl",
           "stroke": "$line-light",
           "strokeWidth": 1,
           "strokeAlignment": "inner",
-          "layout": "none",
+          "layout": "vertical",
+          "gap": 8,
+          "padding": 16,
+          "alignItems": "center",
           "children": [
             {
               "type": "frame",
               "id": "thUzO",
-              "x": 12,
-              "y": 12,
-              "width": "fill_container(244)",
+              "width": "fill_container",
               "gap": 14,
               "alignItems": "center",
               "children": [
@@ -2952,15 +2952,15 @@
             },
             {
               "type": "frame",
-              "id": "ZVOl4",
-              "x": 12,
-              "y": 68,
-              "width": "fill_container(210)",
+              "id": "O9YTe",
+              "name": "Profile Row",
+              "width": "fill_container",
               "fill": "$surface-light",
               "cornerRadius": 14,
               "stroke": "$line-light",
               "strokeWidth": 1,
               "strokeAlignment": "inner",
+              "gap": "$space-7",
               "padding": [
                 12,
                 14
@@ -2968,8 +2968,19 @@
               "alignItems": "center",
               "children": [
                 {
+                  "type": "icon",
+                  "id": "g03CP2",
+                  "name": "User Icon",
+                  "width": 16,
+                  "height": 16,
+                  "icon": "user",
+                  "library": "lucide",
+                  "fill": "$text-light"
+                },
+                {
                   "type": "text",
-                  "id": "e9S1S",
+                  "id": "tv1ph",
+                  "name": "Profile Label",
                   "fill": "$text-light",
                   "content": "Profile settings",
                   "fontFamily": "Inter",
@@ -2980,15 +2991,15 @@
             },
             {
               "type": "frame",
-              "id": "r1nou",
-              "x": 12,
-              "y": 116,
-              "width": "fill_container(210)",
+              "id": "HNtef",
+              "name": "Theme Row",
+              "width": "fill_container",
               "fill": "$surface-light",
               "cornerRadius": 14,
               "stroke": "$line-light",
               "strokeWidth": 1,
               "strokeAlignment": "inner",
+              "gap": "$space-7",
               "padding": [
                 12,
                 14
@@ -2996,10 +3007,21 @@
               "alignItems": "center",
               "children": [
                 {
+                  "type": "icon",
+                  "id": "BnDqh",
+                  "name": "Sun Icon",
+                  "width": 16,
+                  "height": 16,
+                  "icon": "sun",
+                  "library": "lucide",
+                  "fill": "$text-light"
+                },
+                {
                   "type": "text",
-                  "id": "mGzHf",
+                  "id": "aEyOJ",
+                  "name": "Theme Label",
                   "fill": "$text-light",
-                  "content": "Theme and colors",
+                  "content": "Light",
                   "fontFamily": "Inter",
                   "fontSize": 13,
                   "fontWeight": "600"
@@ -3008,15 +3030,15 @@
             },
             {
               "type": "frame",
-              "id": "bYcN7",
-              "x": 12,
-              "y": 164,
-              "width": "fill_container(210)",
+              "id": "ZFCbx",
+              "name": "Language Row",
+              "width": "fill_container",
               "fill": "$surface-light",
               "cornerRadius": 14,
               "stroke": "$line-light",
               "strokeWidth": 1,
               "strokeAlignment": "inner",
+              "gap": "$space-7",
               "padding": [
                 12,
                 14
@@ -3024,8 +3046,58 @@
               "alignItems": "center",
               "children": [
                 {
+                  "type": "icon",
+                  "id": "NsHFj",
+                  "name": "Globe Icon",
+                  "width": 16,
+                  "height": 16,
+                  "icon": "globe",
+                  "library": "lucide",
+                  "fill": "$text-light"
+                },
+                {
                   "type": "text",
-                  "id": "Bi7KB",
+                  "id": "j0zc4",
+                  "name": "Language Label",
+                  "fill": "$text-light",
+                  "content": "English",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "K5nb4q",
+              "name": "Sign Out Row",
+              "width": "fill_container",
+              "fill": "$surface-light",
+              "cornerRadius": 14,
+              "stroke": "$line-light",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "gap": "$space-7",
+              "padding": [
+                12,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "d2Cw4W",
+                  "name": "Log Out Icon",
+                  "width": 16,
+                  "height": 16,
+                  "icon": "log-out",
+                  "library": "lucide",
+                  "fill": "$danger-light"
+                },
+                {
+                  "type": "text",
+                  "id": "fqEdB",
+                  "name": "Sign Out Label",
                   "fill": "$danger-light",
                   "content": "Sign out",
                   "fontFamily": "Inter",
@@ -5845,20 +5917,20 @@
           "x": 748,
           "y": 101,
           "width": "fit_content(236)",
-          "height": "fit_content(216)",
           "fill": "$surface-dark",
           "cornerRadius": "$radius-3xl",
           "stroke": "$line-dark",
           "strokeWidth": 1,
           "strokeAlignment": "inner",
-          "layout": "none",
+          "layout": "vertical",
+          "gap": 8,
+          "padding": 16,
+          "alignItems": "center",
           "children": [
             {
               "type": "frame",
               "id": "I3PUc",
-              "x": 10,
-              "y": 10,
-              "width": "fill_container(216)",
+              "width": "fill_container",
               "gap": "$space-7",
               "alignItems": "center",
               "children": [
@@ -5916,15 +5988,15 @@
             },
             {
               "type": "frame",
-              "id": "hT8wE",
-              "x": 10,
-              "y": 62,
-              "width": "fill_container(216)",
+              "id": "lQRO5",
+              "name": "Profile Row",
+              "width": "fill_container",
               "fill": "$surface-dark",
               "cornerRadius": 14,
               "stroke": "$line-dark",
               "strokeWidth": 1,
               "strokeAlignment": "inner",
+              "gap": "$space-7",
               "padding": [
                 12,
                 14
@@ -5932,8 +6004,19 @@
               "alignItems": "center",
               "children": [
                 {
+                  "type": "icon",
+                  "id": "GYih0",
+                  "name": "User Icon",
+                  "width": 16,
+                  "height": 16,
+                  "icon": "user",
+                  "library": "lucide",
+                  "fill": "$text-dark"
+                },
+                {
                   "type": "text",
-                  "id": "lSzZ5",
+                  "id": "v6TYes",
+                  "name": "Profile Label",
                   "fill": "$text-dark",
                   "content": "Profile",
                   "fontFamily": "Inter",
@@ -5944,15 +6027,15 @@
             },
             {
               "type": "frame",
-              "id": "Xjtu3",
-              "x": 10,
-              "y": 112,
-              "width": "fill_container(216)",
+              "id": "DJf6s",
+              "name": "Theme Row",
+              "width": "fill_container",
               "fill": "$surface-dark",
               "cornerRadius": 14,
               "stroke": "$line-dark",
               "strokeWidth": 1,
               "strokeAlignment": "inner",
+              "gap": "$space-7",
               "padding": [
                 12,
                 14
@@ -5960,10 +6043,21 @@
               "alignItems": "center",
               "children": [
                 {
+                  "type": "icon",
+                  "id": "nJNsB",
+                  "name": "Moon Icon",
+                  "width": 16,
+                  "height": 16,
+                  "icon": "moon",
+                  "library": "lucide",
+                  "fill": "$text-dark"
+                },
+                {
                   "type": "text",
-                  "id": "rovYl",
+                  "id": "Ud2gu",
+                  "name": "Theme Label",
                   "fill": "$text-dark",
-                  "content": "Theme colors",
+                  "content": "Dark",
                   "fontFamily": "Inter",
                   "fontSize": 13,
                   "fontWeight": "600"
@@ -5972,15 +6066,15 @@
             },
             {
               "type": "frame",
-              "id": "TL73y",
-              "x": 10,
-              "y": 162,
-              "width": "fill_container(216)",
+              "id": "Agqy4",
+              "name": "Language Row",
+              "width": "fill_container",
               "fill": "$surface-dark",
               "cornerRadius": 14,
               "stroke": "$line-dark",
               "strokeWidth": 1,
               "strokeAlignment": "inner",
+              "gap": "$space-7",
               "padding": [
                 12,
                 14
@@ -5988,8 +6082,58 @@
               "alignItems": "center",
               "children": [
                 {
+                  "type": "icon",
+                  "id": "P80RzQ",
+                  "name": "Globe Icon",
+                  "width": 16,
+                  "height": 16,
+                  "icon": "globe",
+                  "library": "lucide",
+                  "fill": "$text-dark"
+                },
+                {
                   "type": "text",
-                  "id": "O90LkY",
+                  "id": "oaKCn",
+                  "name": "Language Label",
+                  "fill": "$text-dark",
+                  "content": "English",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "sOzjj",
+              "name": "Sign Out Row",
+              "width": "fill_container",
+              "fill": "$surface-dark",
+              "cornerRadius": 14,
+              "stroke": "$line-dark",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "gap": "$space-7",
+              "padding": [
+                12,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "cbnhC",
+                  "name": "Log Out Icon",
+                  "width": 16,
+                  "height": 16,
+                  "icon": "log-out",
+                  "library": "lucide",
+                  "fill": "$danger-dark"
+                },
+                {
+                  "type": "text",
+                  "id": "LxCD3",
+                  "name": "Sign Out Label",
                   "fill": "$danger-dark",
                   "content": "Sign out",
                   "fontFamily": "Inter",
@@ -9730,20 +9874,20 @@
           "x": 506,
           "y": 95,
           "width": "fit_content(236)",
-          "height": "fit_content(216)",
           "fill": "$surface-dark",
           "cornerRadius": "$radius-3xl",
           "stroke": "$line-dark",
           "strokeWidth": 1,
           "strokeAlignment": "inner",
-          "layout": "none",
+          "layout": "vertical",
+          "gap": 8,
+          "padding": 16,
+          "alignItems": "center",
           "children": [
             {
               "type": "frame",
               "id": "ty8gy",
-              "x": 10,
-              "y": 10,
-              "width": "fill_container(216)",
+              "width": "fill_container",
               "gap": "$space-7",
               "alignItems": "center",
               "children": [
@@ -9801,15 +9945,15 @@
             },
             {
               "type": "frame",
-              "id": "u9F69",
-              "x": 10,
-              "y": 62,
-              "width": "fill_container(216)",
+              "id": "tqhti",
+              "name": "Profile Row",
+              "width": "fill_container",
               "fill": "$surface-dark",
               "cornerRadius": 14,
               "stroke": "$line-dark",
               "strokeWidth": 1,
               "strokeAlignment": "inner",
+              "gap": "$space-7",
               "padding": [
                 12,
                 14
@@ -9817,8 +9961,19 @@
               "alignItems": "center",
               "children": [
                 {
+                  "type": "icon",
+                  "id": "U2276",
+                  "name": "User Icon",
+                  "width": 16,
+                  "height": 16,
+                  "icon": "user",
+                  "library": "lucide",
+                  "fill": "$text-dark"
+                },
+                {
                   "type": "text",
-                  "id": "GqhGs",
+                  "id": "D109Y8",
+                  "name": "Profile Label",
                   "fill": "$text-dark",
                   "content": "Profile",
                   "fontFamily": "Inter",
@@ -9829,15 +9984,15 @@
             },
             {
               "type": "frame",
-              "id": "X4YWg",
-              "x": 10,
-              "y": 112,
-              "width": "fill_container(216)",
+              "id": "OmPu9",
+              "name": "Theme Row",
+              "width": "fill_container",
               "fill": "$surface-dark",
               "cornerRadius": 14,
               "stroke": "$line-dark",
               "strokeWidth": 1,
               "strokeAlignment": "inner",
+              "gap": "$space-7",
               "padding": [
                 12,
                 14
@@ -9845,10 +10000,21 @@
               "alignItems": "center",
               "children": [
                 {
+                  "type": "icon",
+                  "id": "EUzY4",
+                  "name": "Moon Icon",
+                  "width": 16,
+                  "height": 16,
+                  "icon": "moon",
+                  "library": "lucide",
+                  "fill": "$text-dark"
+                },
+                {
                   "type": "text",
-                  "id": "q4FSEc",
+                  "id": "fNifn",
+                  "name": "Theme Label",
                   "fill": "$text-dark",
-                  "content": "Theme colors",
+                  "content": "Dark",
                   "fontFamily": "Inter",
                   "fontSize": 13,
                   "fontWeight": "600"
@@ -9857,15 +10023,15 @@
             },
             {
               "type": "frame",
-              "id": "G6pmAw",
-              "x": 10,
-              "y": 162,
-              "width": "fill_container(216)",
+              "id": "VTbYq",
+              "name": "Language Row",
+              "width": "fill_container",
               "fill": "$surface-dark",
               "cornerRadius": 14,
               "stroke": "$line-dark",
               "strokeWidth": 1,
               "strokeAlignment": "inner",
+              "gap": "$space-7",
               "padding": [
                 12,
                 14
@@ -9873,8 +10039,58 @@
               "alignItems": "center",
               "children": [
                 {
+                  "type": "icon",
+                  "id": "yD6JC",
+                  "name": "Globe Icon",
+                  "width": 16,
+                  "height": 16,
+                  "icon": "globe",
+                  "library": "lucide",
+                  "fill": "$text-dark"
+                },
+                {
                   "type": "text",
-                  "id": "YZ3dY",
+                  "id": "Z27VwR",
+                  "name": "Language Label",
+                  "fill": "$text-dark",
+                  "content": "English",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "CRqPo",
+              "name": "Sign Out Row",
+              "width": "fill_container",
+              "fill": "$surface-dark",
+              "cornerRadius": 14,
+              "stroke": "$line-dark",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "gap": "$space-7",
+              "padding": [
+                12,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "R5ot4",
+                  "name": "Log Out Icon",
+                  "width": 16,
+                  "height": 16,
+                  "icon": "log-out",
+                  "library": "lucide",
+                  "fill": "$danger-dark"
+                },
+                {
+                  "type": "text",
+                  "id": "DzlPA",
+                  "name": "Sign Out Label",
                   "fill": "$danger-dark",
                   "content": "Sign out",
                   "fontFamily": "Inter",
@@ -12761,21 +12977,21 @@
           "id": "xVWNN",
           "x": 68,
           "y": 122,
-          "width": 236,
-          "height": "fit_content(220)",
+          "width": "fit_content(236)",
           "fill": "$surface-dark",
           "cornerRadius": "$radius-3xl",
           "stroke": "$line-dark",
           "strokeWidth": 1,
           "strokeAlignment": "inner",
-          "layout": "none",
+          "layout": "vertical",
+          "gap": 8,
+          "padding": 16,
+          "alignItems": "center",
           "children": [
             {
               "type": "frame",
               "id": "HVhKv",
-              "x": 12,
-              "y": 12,
-              "width": "fill_container(212)",
+              "width": "fill_container",
               "gap": "$space-7",
               "alignItems": "center",
               "children": [
@@ -12833,15 +13049,15 @@
             },
             {
               "type": "frame",
-              "id": "cs9BT",
-              "x": 12,
-              "y": 64,
-              "width": "fill_container(212)",
+              "id": "Cu0fC",
+              "name": "Profile Row",
+              "width": "fill_container",
               "fill": "$surface-dark",
               "cornerRadius": 14,
               "stroke": "$line-dark",
               "strokeWidth": 1,
               "strokeAlignment": "inner",
+              "gap": "$space-7",
               "padding": [
                 12,
                 14
@@ -12849,8 +13065,19 @@
               "alignItems": "center",
               "children": [
                 {
+                  "type": "icon",
+                  "id": "ro1wF",
+                  "name": "User Icon",
+                  "width": 16,
+                  "height": 16,
+                  "icon": "user",
+                  "library": "lucide",
+                  "fill": "$text-dark"
+                },
+                {
                   "type": "text",
-                  "id": "SkDdJ",
+                  "id": "CNBNF",
+                  "name": "Profile Label",
                   "fill": "$text-dark",
                   "content": "Profile settings",
                   "fontFamily": "Inter",
@@ -12861,15 +13088,15 @@
             },
             {
               "type": "frame",
-              "id": "fpByH",
-              "x": 12,
-              "y": 114,
-              "width": "fill_container(212)",
+              "id": "bXebE",
+              "name": "Theme Row",
+              "width": "fill_container",
               "fill": "$surface-dark",
               "cornerRadius": 14,
               "stroke": "$line-dark",
               "strokeWidth": 1,
               "strokeAlignment": "inner",
+              "gap": "$space-7",
               "padding": [
                 12,
                 14
@@ -12877,10 +13104,21 @@
               "alignItems": "center",
               "children": [
                 {
+                  "type": "icon",
+                  "id": "FCjwQ",
+                  "name": "Moon Icon",
+                  "width": 16,
+                  "height": 16,
+                  "icon": "moon",
+                  "library": "lucide",
+                  "fill": "$text-dark"
+                },
+                {
                   "type": "text",
-                  "id": "Z4irqI",
+                  "id": "fqFfO",
+                  "name": "Theme Label",
                   "fill": "$text-dark",
-                  "content": "Theme colors",
+                  "content": "Dark",
                   "fontFamily": "Inter",
                   "fontSize": 13,
                   "fontWeight": "600"
@@ -12889,16 +13127,54 @@
             },
             {
               "type": "frame",
-              "id": "vc0a0",
-              "x": 12,
-              "y": 164,
-              "width": "fill_container(212)",
-              "height": 44,
+              "id": "mWzPd",
+              "name": "Language Row",
+              "width": "fill_container",
               "fill": "$surface-dark",
               "cornerRadius": 14,
               "stroke": "$line-dark",
               "strokeWidth": 1,
               "strokeAlignment": "inner",
+              "gap": "$space-7",
+              "padding": [
+                12,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "d30sp",
+                  "name": "Globe Icon",
+                  "width": 16,
+                  "height": 16,
+                  "icon": "globe",
+                  "library": "lucide",
+                  "fill": "$text-dark"
+                },
+                {
+                  "type": "text",
+                  "id": "e5hE2N",
+                  "name": "Language Label",
+                  "fill": "$text-dark",
+                  "content": "English",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "CDkcQ",
+              "name": "Sign Out Row",
+              "width": "fill_container",
+              "fill": "$surface-dark",
+              "cornerRadius": 14,
+              "stroke": "$line-dark",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "gap": "$space-7",
               "padding": [
                 12,
                 14,
@@ -12908,8 +13184,19 @@
               "alignItems": "center",
               "children": [
                 {
+                  "type": "icon",
+                  "id": "o5g9I",
+                  "name": "Log Out Icon",
+                  "width": 16,
+                  "height": 16,
+                  "icon": "log-out",
+                  "library": "lucide",
+                  "fill": "$danger-dark"
+                },
+                {
                   "type": "text",
-                  "id": "mPlMG",
+                  "id": "k2DMJT",
+                  "name": "Sign Out Label",
                   "fill": "$danger-dark",
                   "content": "Sign out",
                   "fontFamily": "Inter",

--- a/docs/development-logs/Task FAV-25 improve-application-localization-and-not-found-experience.md
+++ b/docs/development-logs/Task FAV-25 improve-application-localization-and-not-found-experience.md
@@ -81,7 +81,7 @@ A canonical plan was authored at `docs/plan/Plan FAV-25 Improve application loca
 
 ### Shared logging (`src/shared/logging/`)
 
-- `logger.ts`: minimal `appLogger` (`error`/`warn` with optional context object) wrapping `console`. Used by root optional-session error handling. Pino deferred to later wiring (AGENTS.md lists Pino as preferred logger; current scaffold is console-based).
+- `logger.ts`: Pino-backed `appLogger` (`error`/`warn` with optional context object) for shared application logging. Config strips default base fields, emits browser logs as objects, and stays silent in tests.
 
 ### QA / Review Fix Loops & Smoke / E2E Additions
 
@@ -204,7 +204,7 @@ A canonical plan was authored at `docs/plan/Plan FAV-25 Improve application loca
 
 9. **`data-locale-locked` bootstrap short-circuit**: Authenticated SSR emits canonical `<html lang>` and locks the bootstrap script to prevent client override flash; anonymous SSR stays English-safe and corrects post-hydration.
 
-10. **Minimal console-based logger scaffold**: `appLogger` wraps console for root optional-session error handling. Pino (AGENTS.md preferred) deferred to dedicated wiring task.
+10. **Pino-backed shared logger**: `appLogger` fronts Pino for shared application logging, keeps browser output structured, strips default base fields, and stays silent in tests.
 
 ## Validation Performed
 
@@ -220,7 +220,7 @@ A canonical plan was authored at `docs/plan/Plan FAV-25 Improve application loca
 - **Anonymous SSR cannot know browser/localStorage locale**: Bootstrap script + provider correct client state as early as possible; anonymous first paint is English-safe by design. Acceptable per plan.
 - **OAuth callback timing for hint cookie**: First-login seeding bridge is isolated to auth config. If brittle, fall back to a first-post-auth sync without reworking the locale architecture.
 - **Better Auth inferred-additional-field client typing gap**: `updateBrowserUserLocale` uses direct POST until upstream client typing flows `locale` into `authClient.updateUser`. Revisit on better-auth upgrade.
-- **Pino not yet wired**: `appLogger` is console-based. Replace with Pino (AGENTS.md preferred logger) in a dedicated logging task.
+- **Logger surface intentionally minimal**: `appLogger` currently exposes only `warn`/`error` on top of Pino because current localization/not-found flow only needs failure-path logging. Expand only if broader log levels become necessary.
 - **`user.locale` self-heal read path**: `repairSessionLocale` writes on read when locale missing/invalid. Monitor for write-amplification if locale hints arrive stale repeatedly.
 - **Translation completeness**: Only `en`/`es`/`pt-BR` ship now. Adding locales requires updating `supportedLocales`, resource files, browser mapping, and bootstrap script in lockstep.
 - **404 design-token drift**: Styling must stay token-only. Future 404 tweaks should map to existing token variables before any hard-coded values.

--- a/docs/development-logs/Task FAV-25 improve-application-localization-and-not-found-experience.md
+++ b/docs/development-logs/Task FAV-25 improve-application-localization-and-not-found-experience.md
@@ -1,0 +1,227 @@
+---
+title: FAV-25 Improve Application Localization and Not-Found Experience
+type: development-log
+permalink: docs/development-logs/task-FAV-25-improve-application-localization-and-not-found-experience
+---
+
+# Development Log: FAV-25
+
+## Metadata
+
+- Task ID: FAV-25 (epic)
+- Date (UTC): 2026-06-14T12:00:00Z
+- Project: favoritable
+- Branch: feature/FAV-25-improve-application-localization-and-not-found-experience
+- Commit: uncommitted (working-tree changes, pending final commit)
+
+## Objective
+
+Deliver the FAV-25 epic: app-wide internationalization (FAV-27) with canonical locale persistence and a shell-aware localized 404 experience (FAV-26), without locale segments in URLs and without changing existing known route behavior.
+
+Epic decomposed into two child issues, delivered sequentially (FAV-27 first, FAV-26 second):
+
+- **FAV-27**: Shared i18n runtime (typed locale contract, TS translation resources, `LocaleProvider` mirroring the theme runtime), Better Auth canonical `locale` persistence, first-login locale seeding via short-lived hint cookie, signed-out + signed-in language switching, and a full visible-copy translation sweep.
+- **FAV-26**: Shared localized `NotFoundContent` component built from `docs/design/favoritable.pen`, two thin wrappers (public standalone + protected shell-wrapped), root-level `notFoundComponent` selection driven by optional session context.
+
+A canonical plan was authored at `docs/plan/Plan FAV-25 Improve application localization and not-found experience.md` covering task analysis, chosen approach, implementation steps, and validation.
+
+## Implementation Summary
+
+### Planning & Architecture
+
+- Approved plan at `docs/plan/Plan FAV-25 ...md`: 11-step implementation sequence, locale precedence `localStorage -> browser mapping -> en`, server-canonical locale inside Better Auth user data (no parallel table), root optional-session context for auth-aware 404, no URL locale routing.
+- Chose to mirror existing `ThemeProvider` + bootstrap-script pattern instead of URL locale routing or a separate cookie-first localization architecture.
+
+### FAV-27 — Internationalization & Canonical Locale Persistence
+
+#### Shared i18n runtime (`src/shared/i18n/`)
+
+- `locale.ts`: canonical locale type `Locale = 'en' | 'pt-BR' | 'es'`, `isLocale`/`normalizeLocale` validators, `mapBrowserLanguageToLocale` base-language mapping (`pt-* -> pt-BR`, `es-* -> es`, `en-* -> en`, else `en`), localStorage helpers (`favoritable-locale` key), document `<html lang>` apply, locale-hint cookie helpers (`favoritable-locale-hint`, 10-min max-age, `SameSite=Lax`), `getLocaleHintFromCookieHeader` parser, and an inline `localeBootstrapScript` mirroring the theme bootstrap to set `<html lang>` before hydration with a `data-locale-locked` short-circuit for authenticated SSR.
+- `i18n.ts`: `createI18nInstance(locale)` using `i18next` `createInstance` + `initReactI18next`, English fallback, `supportedLngs`, `load: 'currentOnly'`, `initAsync: false`, `returnNull: false`.
+- `LocaleProvider.tsx`: React context over `I18nextProvider`; resolves initial locale from normalized server locale (authenticated) or `resolveClientLocale`; syncs `<html lang>` + localStorage + i18n language on change; authenticated path overrides stale client cache with server locale and clears hint cookie; optimistic signed-in updates via `updateBrowserUserLocale` with `confirmedLocaleRef` + request-id race guard + rollback to last confirmed locale + non-blocking localized error flag; exposes `locale`, `setLocale`, `isUpdatingLocale`, `localeUpdateError`, `clearLocaleUpdateError`.
+- `resources/en.ts`, `resources/es.ts`, `resources/pt-BR.ts`: all current visible user-facing copy translated across `appShell`, `auth` (hero, panel, footer, providers), `home`, `notFound`, `profileMenu`, `theme`, `common`, `locale.names`. English is fallback; interpolation placeholders used for `{{year}}`, `{{callbackPath}}`, `{{identity}}`.
+- `components/LanguageSwitcher.tsx` + `.module.css`: reusable Base UI `@base-ui/react/select`-backed selector, `align`/`className`/`disabled` props, `onLocaleChange` callback, localized label + option names, indicator. Reused on both login and profile surfaces.
+
+#### Auth persistence & seeding (`src/features/auth/`)
+
+- `server/auth.server.ts`: added `user.additionalFields.locale` (`string`, `input: true`, `required: false`, `returned: true`); `databaseHooks.user.create.before` seeds locale via `resolveCanonicalLocale(request, candidate)` (candidate -> hint cookie -> `en` fallback); `databaseHooks.user.update.before` validates locale and throws `APIError('BAD_REQUEST')` on unsupported values; `repairSessionLocale()` self-heals missing/invalid server locale on read by calling `updateUser`, returning a typed `AuthSessionWithLocale`. `getServerAuthSession` now returns locale-enriched session.
+- `lib/auth-client.ts`: `inferAdditionalFields` plugin with `locale` field schema for typed session/user locale access on client; `updateBrowserUserLocale(locale)` isolated helper that POSTs `/update-user` directly (Better Auth inferred-additional-field input typing does not currently flow into `authClient.updateUser` for `locale`), parses mutation payload, returns `{ error } | { error: null }`.
+- `lib/auth-defaults.ts`: removed hardcoded English strings (`googleOAuthSetupMessage`, `signOutErrorMessage`) now in translation resources; exported `googleOAuthCallbackPath` for interpolation.
+- `lib/auth-providers.ts`: replaced `authProviderCopy` literal map with `authProviderIcons` map only (labels/loading labels moved to i18n resources).
+
+#### Root session & document integration (`src/routes/__root.tsx`)
+
+- Added `beforeLoad` optional session load via `loadOptionalRouteSession()` (wraps `getRouteAuthSession`, catches known session-load error and logs warnings/errors via `appLogger`, returns `null` for signed-out fallback). Root now carries `{ session }` in route context.
+- `RootDocument`: emits canonical `<html lang>` (server locale when authenticated, `defaultLocale` otherwise), sets `data-locale-locked` on authenticated SSR to lock bootstrap, injects both theme + locale bootstrap scripts, wraps app in `<LocaleProvider isAuthenticated serverLocale>` composed inside `<ThemeProvider>`.
+- Root `notFoundComponent` (see FAV-26).
+
+#### Copy surfaces translated/wired
+
+- `LoginPage.tsx`, `ProviderButton.tsx`, `ProtectedAppShell.tsx`, `ProtectedHomePage.tsx`, `ProfileMenu.tsx`, `ThemeToggle.tsx`: literals replaced with `useTranslation()` `t()` calls; `LanguageSwitcher` added to login (signed-out, localStorage-only) and `ProfileMenu` (signed-in, optimistic + persisted).
+
+#### First-login locale seeding bridge
+
+- `LoginPage` writes `favoritable-locale-hint` cookie at Google sign-in start; Better Auth `user.create.before` hook normalizes and persists it server-side; hint cleared post-auth by `LocaleProvider`. Bridge isolated to auth config so a first-post-auth sync fallback remains possible.
+
+### FAV-26 — Shell-Aware Localized 404
+
+#### Not-found feature (`src/features/not-found/`)
+
+- `components/NotFoundContent.tsx` + `.module.css`: shared localized 404 content — 404 code, localized heading + description (via `t('notFound.*')`), `Link` CTA with `actionHref`/`actionLabel` props, configurable `headingLevel` (`h1` public, `h2` protected). Styling uses design tokens only (no hard-coded colors/spacing/typography), responsive mobile/tablet/desktop, light/dark.
+- `views/PublicNotFoundPage.tsx`: standalone full-viewport 404, CTA `Go to login` -> `/login`.
+- `views/ProtectedNotFoundPage.tsx`: wraps `NotFoundContent` inside `<ProtectedAppShell>`, CTA `Go home` -> `/`, `headingLevel="h2"`.
+
+#### Root not-found wiring (`src/routes/__root.tsx`)
+
+- `RootNotFoundComponent`: reads root optional-session context; renders `<ProtectedNotFoundPage>` when session exists, `<PublicNotFoundPage>` otherwise. Unknown anonymous paths render standalone 404 without auth redirect; unknown authenticated paths render shell-wrapped 404. Existing routes/guards unchanged.
+
+#### Route guard refactor (`src/features/auth/routes/route-auth.ts`)
+
+- Added `getRouteContextAuthSession(context)` to read root-loaded session from route context. `redirectIfLoggedOut`/`redirectIfLoggedIn` now accept an optional preloaded session, avoiding duplicate session fetches. `_protected.tsx` and `login.tsx` consume root context session when available, falling back to direct fetch.
+
+### Shared logging (`src/shared/logging/`)
+
+- `logger.ts`: minimal `appLogger` (`error`/`warn` with optional context object) wrapping `console`. Used by root optional-session error handling. Pino deferred to later wiring (AGENTS.md lists Pino as preferred logger; current scaffold is console-based).
+
+### QA / Review Fix Loops & Smoke / E2E Additions
+
+- Unit: `test/shared/i18n/locale.test.ts` (locale validators, browser mapping, cookie parsing, hint helpers); `test/features/auth/server/auth.server.test.ts` (create/update locale hooks, unsupported-locale rejection); `auth-bootstrap.test.ts` + `auth-client.test.ts` (locale field schema, `updateBrowserUserLocale` payload parsing).
+- Browser/component: `test/shared/i18n/LocaleProvider.browser.test.tsx` (signed-out localStorage precedence, optimistic authenticated update + rollback, html-lang sync — screenshot-gated); `test/features/not-found/components/NotFoundContent.browser.test.tsx` (localized copy from active locale — screenshot-gated); updated login/provider/theme/shell/profile tests for i18n wiring.
+- Route/integration: `test/routes/root-not-found.browser.test.tsx` (protected shell 404 for signed-in, standalone localized 404 for signed-out — screenshot-gated); `test/routes/root.test.ts`; `test/routes/auth-routes.test.tsx` (schema/session locale availability, invalid server-locale fallback).
+- E2E smoke (all `@smoke`): `e2e/tests/locale-smoke.spec.ts` (signed-out locale switch persists across reload; authenticated profile locale switch persists across reload); `e2e/tests/not-found-smoke.spec.ts` (unknown public route -> standalone localized 404, CTA `/login`); `e2e/tests/auth/authenticated-not-found-smoke.spec.ts` (unknown authenticated route -> shell-wrapped 404, CTA `/`).
+- Test support: `src/test-support/TestI18nProvider.tsx` render helper wrapping `LocaleProvider` for component tests.
+- `e2e/utils/routes.ts`: added `unknownPublic` route constant.
+- Review/QA loops: browser screenshot fixtures captured for visual regression on `NotFoundContent`, `LocaleProvider`, and root not-found wrappers.
+
+### Final Validation
+
+- `pnpm complete-check` run as the final regression gate (knip, typecheck, lint, format, unit + browser tests, build, E2E smoke). Full localization + 404 coverage green.
+
+## Files Changed
+
+### New — Shared i18n Runtime
+
+- `src/shared/i18n/locale.ts` — Locale type, validators, browser mapping, localStorage + hint-cookie helpers, bootstrap script
+- `src/shared/i18n/i18n.ts` — i18next instance factory
+- `src/shared/i18n/LocaleProvider.tsx` — Locale context, optimistic signed-in updates, rollback, document sync
+- `src/shared/i18n/resources/en.ts` / `es.ts` / `pt-BR.ts` — Translation resources
+- `src/shared/i18n/components/LanguageSwitcher.tsx` / `.module.css` — Reusable Base UI locale selector
+
+### New — Not-Found Feature (FAV-26)
+
+- `src/features/not-found/components/NotFoundContent.tsx` / `.module.css` — Shared localized 404 content
+- `src/features/not-found/views/PublicNotFoundPage.tsx` — Standalone 404, CTA `/login`
+- `src/features/not-found/views/ProtectedNotFoundPage.tsx` — Shell-wrapped 404, CTA `/`
+
+### New — Shared Logging & Test Support
+
+- `src/shared/logging/logger.ts` — `appLogger` (error/warn)
+- `src/test-support/TestI18nProvider.tsx` — i18n render helper for component tests
+
+### Modified — Auth Persistence & Locale Seeding
+
+- `src/features/auth/server/auth.server.ts` — `user.locale` additional field, create/update hooks, `repairSessionLocale`, typed locale-enriched session
+- `src/features/auth/lib/auth-client.ts` — `inferAdditionalFields` locale schema, `updateBrowserUserLocale` mutation helper
+- `src/features/auth/lib/auth-defaults.ts` — Removed hardcoded English strings; exported `googleOAuthCallbackPath`
+- `src/features/auth/lib/auth-providers.ts` — `authProviderIcons` map (labels moved to i18n)
+- `src/features/auth/routes/route-auth.ts` — `getRouteContextAuthSession`, optional-session params on guards, exported `routeAuthErrorMessage`
+
+### Modified — Root, Routes & Document Integration
+
+- `src/routes/__root.tsx` — Optional session `beforeLoad`, locale bootstrap, `<html lang>` + `data-locale-locked`, `LocaleProvider` wiring, root `notFoundComponent` selection
+- `src/routes/_protected.tsx` — Consumes root context session; falls back to guard fetch
+- `src/routes/login.tsx` — Consumes root context session
+
+### Modified — Copy Surfaces (i18n wiring)
+
+- `src/features/auth/components/LoginPage.tsx` — `useTranslation`, language switcher (signed-out), hint cookie on sign-in
+- `src/features/auth/components/ProviderButton.tsx` — Localized label/loading
+- `src/features/app-shell/views/ProtectedAppShell.tsx` — Localized copy, skip-link
+- `src/features/app-shell/views/ProtectedHomePage.tsx` — Localized copy
+- `src/features/app-shell/components/ProfileMenu.tsx` / `.module.css` — Language switcher (signed-in), localized labels
+- `src/shared/theme/ThemeToggle.tsx` — Localized `dark mode` label
+
+### Modified — Schema & Migrations
+
+- `src/db/schema/auth.ts` — `locale` text column on `user`
+- `drizzle/0001_strange_medusa.sql` — `ALTER TABLE user ADD locale text`
+- `drizzle/meta/_journal.json` / `0001_snapshot.json` — Migration metadata
+
+### Modified — Dependencies & Config
+
+- `package.json` — Added `i18next ~26.3.1`, `react-i18next ~17.0.8`
+- `pnpm-lock.yaml` — Lockfile updated
+
+### New — Tests
+
+- `test/shared/i18n/locale.test.ts`
+- `test/shared/i18n/LocaleProvider.browser.test.tsx` (+ screenshot fixtures)
+- `test/features/not-found/components/NotFoundContent.browser.test.tsx` (+ screenshot fixtures)
+- `test/routes/root-not-found.browser.test.tsx` (+ screenshot fixtures)
+- `test/routes/root.test.ts`
+
+### New — E2E Smoke
+
+- `e2e/tests/locale-smoke.spec.ts` (@smoke)
+- `e2e/tests/not-found-smoke.spec.ts` (@smoke)
+- `e2e/tests/auth/authenticated-not-found-smoke.spec.ts` (@smoke)
+- `e2e/utils/routes.ts` — `unknownPublic` constant
+
+### Modified — Tests (i18n wiring updates)
+
+- `test/features/auth/components/LoginPage.browser.test.tsx`
+- `test/features/auth/components/ProviderButton.browser.test.tsx`
+- `test/features/auth/lib/auth-client.test.ts`
+- `test/features/auth/server/auth-bootstrap.test.ts`
+- `test/features/auth/server/auth.server.test.ts`
+- `test/features/app-shell/components/ProfileMenu.browser.test.tsx`
+- `test/features/app-shell/views/ProtectedAppShell.browser.test.tsx`
+- `test/features/app-shell/views/ProtectedHomePage.browser.test.tsx`
+- `test/routes/auth-routes.test.tsx`
+- `test/shared/theme/ThemeToggle.browser.test.tsx`
+
+### Documentation
+
+- `docs/plan/Plan FAV-25 Improve application localization and not-found experience.md` — Canonical approved plan
+
+## Key Decisions
+
+1. **Mirror theme runtime, not URL routing**: Locale resolved via localStorage + browser mapping + bootstrap script, canonical value on Better Auth user. Avoids locale-in-URL complexity and anonymous-SSR-locale-blindness workarounds.
+
+2. **Server-canonical locale inside Better Auth user data**: `user.additionalFields.locale` is the single signed-in source of truth. No parallel preferences table, no custom locale API.
+
+3. **First-login locale seeding via short-lived hint cookie**: `favoritable-locale-hint` (10-min max-age) bridges client locale to server during social auth. Bridge isolated to auth config so a first-post-auth sync fallback remains possible if OAuth callback timing proves brittle.
+
+4. **Root optional session context (single load)**: Root `beforeLoad` loads session once; `_protected`/`login` guards and root 404 selection all consume it via `getRouteContextAuthSession`. Eliminates duplicate session fetches and enables auth-aware 404 without changing route structure.
+
+5. **Optimistic signed-in locale update with rollback**: `LocaleProvider` updates UI immediately, persists via `updateBrowserUserLocale`, rolls back to last confirmed locale with a non-blocking localized error on failure. Request-id guard prevents race conditions.
+
+6. **Auth config as schema source of truth**: `user.additionalFields.locale` drives Drizzle schema; migration regenerated from it rather than hand-maintained divergent definitions.
+
+7. **`updateBrowserUserLocale` isolated direct POST**: Better Auth inferred-additional-field input typing does not currently flow into `authClient.updateUser` for `locale`. Kept contract isolated in `auth-client.ts` until upstream client typing owns it.
+
+8. **Shared `NotFoundContent` + two thin wrappers**: One localized component, public (`h1`, CTA `/login`) and protected (`h2`, CTA `/`) wrappers. Design tokens only; no hard-coded styling.
+
+9. **`data-locale-locked` bootstrap short-circuit**: Authenticated SSR emits canonical `<html lang>` and locks the bootstrap script to prevent client override flash; anonymous SSR stays English-safe and corrects post-hydration.
+
+10. **Minimal console-based logger scaffold**: `appLogger` wraps console for root optional-session error handling. Pino (AGENTS.md preferred) deferred to dedicated wiring task.
+
+## Validation Performed
+
+- **Unit tests**: locale validators/browser-mapping/cookie parsing; auth server create/update locale hooks, unsupported-locale rejection, bootstrap seeding; auth-client locale schema + mutation payload parsing.
+- **Browser/component tests**: `LocaleProvider` signed-out localStorage precedence, optimistic authenticated update + rollback, `<html lang>` sync; `NotFoundContent` localized copy; updated login/provider/theme/shell/profile tests. Screenshot fixtures captured for visual regression.
+- **Route/integration tests**: root not-found renders protected shell 404 for signed-in and standalone localized 404 for signed-out; schema/session locale availability; invalid server-locale fallback.
+- **E2E smoke (@smoke)**: signed-out locale switch persists across reload; authenticated profile locale switch persists across reload; unknown public route -> standalone localized 404 (CTA `/login`); unknown authenticated route -> shell-wrapped 404 (CTA `/`).
+- **Final regression gate**: `pnpm complete-check` (knip, typecheck, lint, format, unit + browser tests, build, E2E smoke) green.
+- **Manual QA**: locale switching on login + profile; `<html lang>` updates; reload persistence (localStorage signed-out, Better Auth user signed-in); 404 renders standalone vs shell-wrapped by auth state; CTA targets correct.
+
+## Risks and Follow-ups
+
+- **Anonymous SSR cannot know browser/localStorage locale**: Bootstrap script + provider correct client state as early as possible; anonymous first paint is English-safe by design. Acceptable per plan.
+- **OAuth callback timing for hint cookie**: First-login seeding bridge is isolated to auth config. If brittle, fall back to a first-post-auth sync without reworking the locale architecture.
+- **Better Auth inferred-additional-field client typing gap**: `updateBrowserUserLocale` uses direct POST until upstream client typing flows `locale` into `authClient.updateUser`. Revisit on better-auth upgrade.
+- **Pino not yet wired**: `appLogger` is console-based. Replace with Pino (AGENTS.md preferred logger) in a dedicated logging task.
+- **`user.locale` self-heal read path**: `repairSessionLocale` writes on read when locale missing/invalid. Monitor for write-amplification if locale hints arrive stale repeatedly.
+- **Translation completeness**: Only `en`/`es`/`pt-BR` ship now. Adding locales requires updating `supportedLocales`, resource files, browser mapping, and bootstrap script in lockstep.
+- **404 design-token drift**: Styling must stay token-only. Future 404 tweaks should map to existing token variables before any hard-coded values.
+- **No automated structural-lint enforcement of feature-sliced boundaries**: Architecture skill defines rules but no guard rails yet (carried over from FAV-1).

--- a/docs/plan/Plan FAV-25 Improve application localization and not-found experience.md
+++ b/docs/plan/Plan FAV-25 Improve application localization and not-found experience.md
@@ -1,0 +1,86 @@
+## Task Analysis
+
+- Main objective: Deliver FAV-25 by landing FAV-27 first and FAV-26 second: app-wide i18n with canonical locale persistence plus a shell-aware localized 404, without locale segments in URLs and without changing existing known route behavior.
+- Identified dependencies:
+  - New runtime dependencies: `i18next` and `react-i18next`.
+  - Better Auth user additional field + Drizzle migration for canonical `locale` persistence.
+  - Root optional session context in `src/routes/__root.tsx` so locale and 404 rendering can make authenticated vs anonymous decisions without disturbing existing route guards.
+  - Existing surfaces and design sources already in repo: `src/routes/login.tsx`, `src/routes/_protected.tsx`, `src/routes/_protected/index.tsx`, `src/features/app-shell/views/ProtectedAppShell.tsx`, `src/features/app-shell/components/ProfileMenu.tsx`, `src/shared/theme/**`, and `docs/design/favoritable.pen`.
+- System impact:
+  - Add a shared i18n runtime under `src/shared/i18n/**`, intentionally mirroring current theme runtime patterns in `src/shared/theme/**`.
+  - Auth persistence changes touch `src/features/auth/server/auth.server.ts`, `src/features/auth/lib/auth-client.ts`, `src/db/schema/auth.ts`, and new `drizzle` migration/meta files.
+  - Visible-copy translation sweep touches current auth, shell, theme toggle, and new 404 surfaces; tests expand across unit, browser/component, route/integration, and Playwright smoke layers.
+  - Key risks: anonymous first SSR request cannot know localStorage/browser locale; first-login locale seeding needs a client-to-server bridge during social auth; Better Auth client typing must stay aligned with the new `user.locale` field.
+
+## Chosen Approach
+
+- Proposed solution:
+  - Add one shared i18n runtime centered on typed locale helpers, TS-based translation resources, and a `LocaleProvider` that mirrors the current theme provider/bootstrap model.
+  - Store canonical locale on the Better Auth user via `user.additionalFields.locale`, infer that field on the client, and use Better Auth user updates as the only signed-in persistence path.
+  - Seed locale for first auth bootstrap with a short-lived locale hint cookie written at Google sign-in start, then normalized and persisted server-side only when the server locale is missing or invalid.
+  - Implement FAV-26 with one shared localized `NotFoundContent` component plus two thin wrappers: public standalone and protected shell wrapper. Choose wrapper from root optional-session context so current route structure stays intact.
+- Justification for simplicity:
+  - Reuses the existing `ThemeProvider` + bootstrap-script pattern instead of adding URL locale routing, cookie-first localization architecture, or a second global state store.
+  - Keeps server-canonical locale inside Better Auth user data, avoiding a parallel profile/preferences table or custom API surface for locale persistence.
+  - Uses root-level optional session and root-level not-found handling, so current routes remain thin and existing `/login` and protected-home behavior stays stable.
+- Components to be modified/created:
+  - Dependencies/config:
+    - `package.json` — add `i18next` and `react-i18next`.
+  - Shared i18n runtime:
+    - `src/shared/i18n/locale.ts` — canonical locale type, validation, browser mapping, localStorage helpers, and `html lang` bootstrap/apply logic.
+    - `src/shared/i18n/i18n.ts` — i18next init with English fallback and no-URL locale strategy.
+    - `src/shared/i18n/LocaleProvider.tsx` — active locale state, server override, optimistic signed-in updates, rollback handling, and document sync.
+    - `src/shared/i18n/resources/en.ts`, `src/shared/i18n/resources/pt-BR.ts`, `src/shared/i18n/resources/es.ts` — all current visible user-facing copy translated.
+    - `src/shared/i18n/components/LanguageSwitcher.tsx` + `LanguageSwitcher.module.css` — shared Base UI-backed selector reused on login and profile surfaces.
+  - Root/auth/persistence:
+    - `src/routes/__root.tsx` — optional session load, locale bootstrap script, `html lang`, provider wiring, and root `notFoundComponent`.
+    - `src/features/auth/server/auth.server.ts` — `locale` additional field, server normalization, and auth-bootstrap seeding hook.
+    - `src/features/auth/lib/auth-client.ts` — Better Auth client additional-field inference and typed session/user locale access.
+    - `src/db/schema/auth.ts` + `drizzle/*` migration/meta — persisted `user.locale` column.
+  - Current copy surfaces to translate/wire:
+    - `src/features/auth/components/LoginPage.tsx` + `LoginPage.module.css`
+    - `src/features/auth/components/ProviderButton.tsx`
+    - `src/features/auth/lib/auth-defaults.ts`
+    - `src/features/auth/lib/auth-providers.ts`
+    - `src/features/app-shell/views/ProtectedAppShell.tsx`
+    - `src/features/app-shell/components/ProfileMenu.tsx` + `ProfileMenu.module.css`
+    - `src/features/app-shell/views/ProtectedHomePage.tsx`
+    - `src/shared/theme/ThemeToggle.tsx`
+  - 404 feature:
+    - `src/features/not-found/components/NotFoundContent.tsx` + `NotFoundContent.module.css`
+    - `src/features/not-found/views/PublicNotFoundPage.tsx`
+    - `src/features/not-found/views/ProtectedNotFoundPage.tsx`
+  - Tests/helpers:
+    - `test/shared/i18n/locale.test.ts`
+    - `test/shared/i18n/LocaleProvider.browser.test.tsx`
+    - `test/shared/i18n/TestI18nProvider.tsx` or equivalent render helper
+    - updates/new tests under `test/features/auth/**`, `test/features/app-shell/**`, `test/routes/**`, and `test/router.test.ts`
+    - updates/new smoke coverage under `e2e/tests/**`
+
+## Implementation Steps
+
+1. FAV-27 — Add i18n dependencies and establish the locale contract in `src/shared/i18n/locale.ts`: supported locales `en | pt-BR | es`, strict validators, browser base-language mapping (`pt-* -> pt-BR`, `es-* -> es`, `en-* -> en`, else `en`), localStorage key, safe English fallback rules, and an inline bootstrap helper for `html lang`. Pre-implementation checkpoint: lock this behavior down with unit tests before any UI wiring.
+2. FAV-27 — Extend Better Auth to own canonical locale: add `user.additionalFields.locale` in `src/features/auth/server/auth.server.ts`, update/generate `src/db/schema/auth.ts`, create the Drizzle migration under `drizzle/`, and update auth bootstrap/migration tests. Mitigation: treat auth config as schema source of truth and regenerate from it, instead of hand-maintaining divergent auth/schema definitions.
+3. FAV-27 — Add first-login locale seeding: when `LoginPage` starts Google sign-in, write a short-lived locale hint cookie from the resolved client locale; in Better Auth server hooks, normalize that value, seed user locale only when the current server locale is missing or invalid, and clear the hint after use. Risk note: OAuth callback timing can be tricky; keep this bridge isolated to auth config so fallback to a first-post-auth sync is possible without reworking the rest of the locale architecture.
+4. FAV-27 — Create `src/shared/i18n/i18n.ts` and `LocaleProvider.tsx` to mirror the existing theme runtime: initialize `react-i18next`, sync `html lang`, resolve signed-out locale from `localStorage -> browser mapping -> en`, and immediately override stale client cache with normalized server locale once a signed-in session is known. Mitigation: because anonymous SSR cannot know browser/localStorage locale without URL or cookie state, keep SSR fallback English-safe and use bootstrap + provider initialization to correct client state as early as possible.
+5. FAV-27 — Wire root session and document integration in `src/routes/__root.tsx`: add optional auth session `beforeLoad`, pass initial locale/session context into `LocaleProvider`, preserve `ThemeProvider` composition, and use the same root context later for auth-aware 404 selection. Checkpoint: authenticated SSR should emit canonical `html lang`; anonymous requests should remain stable with English fallback and no locale path changes.
+6. FAV-27 — Translate all current visible user-facing copy and add signed-out locale switching: move literals from login/auth/provider/shell/theme surfaces into TS translation resources, add the shared language switcher to `LoginPage`, persist signed-out changes to localStorage only, and keep user-facing provider/auth error messages localized with English fallback interpolation where needed.
+7. FAV-27 — Add signed-in locale switching in the protected shell: reuse the shared language switcher in `ProfileMenu`, update UI optimistically through `LocaleProvider`, persist immediately with Better Auth user update, rollback to the last confirmed server locale on failure, and show a non-blocking localized error without disrupting the rest of the shell. Mitigation: if Better Auth session hooks do not reflect the updated locale quickly enough, refetch session in the provider instead of adding a second persistence endpoint.
+8. FAV-27 — Expand localization verification: update browser/component tests for login, provider buttons, theme toggle label, profile menu, protected shell, and locale provider behavior; add route/auth tests for schema/session locale availability and invalid server-locale fallback; add at least one Playwright smoke path that proves locale persistence across reload for anonymous or authenticated flow.
+9. FAV-26 — Build the shared 404 feature from `docs/design/favoritable.pen`: implement `NotFoundContent` plus CSS Module using existing design tokens and Pencil’s mobile/tablet/desktop light/dark guidance, then add two thin wrappers—public standalone and protected shell wrapper—with localized heading/body/CTA copy. Risk note: 404 styling can drift from design if convenience wins; mitigation is to map only existing token variables first and avoid hard-coded colors, spacing, or typography.
+10. FAV-26 — Wire shell-aware not-found behavior without changing URL structure: use the root optional-session context in `src/routes/__root.tsx` to choose the public or protected wrapper, point signed-out CTA to `/login`, point signed-in CTA to the current protected home `/`, and keep existing known routes and guards unchanged. Checkpoint: unknown anonymous path must not redirect into auth-guard flow, and unknown authenticated path must render inside `ProtectedAppShell`.
+11. FAV-26 — Add 404 coverage at all layers: component tests for shared content and wrappers, route/integration tests for auth-aware wrapper selection, and Playwright smoke coverage for unknown public and authenticated routes. Final regression gate: run `pnpm complete-check`. Rollback note: if dedicated smoke specs prove unstable, fold the assertions into the existing smoke files first and split later only after stability is proven.
+
+## Validation
+
+- Success criteria:
+  - FAV-27: app resolves locale with precedence `localStorage -> browser mapping -> en` before auth, persists canonical locale on the Better Auth user after auth, updates `<html lang>`, translates all current visible user-facing copy, and falls back to English on missing keys or invalid stored/server locales.
+  - FAV-27: login switcher remains localStorage-only before auth; protected switcher updates optimistically, persists immediately, and rolls back with non-blocking localized error if save fails.
+  - FAV-26: unknown public routes show a localized standalone 404; unknown authenticated routes show the same localized content inside `ProtectedAppShell`; CTA targets are `/login` and `/` respectively; current known routes keep current behavior.
+  - Repo passes `pnpm complete-check` unchanged.
+- Checkpoints:
+  - Pre-implementation assumptions check: confirm Better Auth client additional-field inference and user-update API cover all signed-in persistence needs; confirm `docs/design/favoritable.pen` remains the 404 source of truth; confirm no locale-in-URL work is introduced.
+  - During Steps 1-3: unit tests prove locale normalization/fallback behavior; migration/bootstrap tests prove `user.locale` exists; first-auth bootstrap seeds missing locale from resolved client value only.
+  - During Steps 4-7: anonymous reload keeps chosen login locale; authenticated session immediately overrides stale localStorage; failed signed-in locale save restores the prior confirmed locale and leaves the app usable.
+  - During Steps 9-10: unknown anonymous path renders standalone 404 without auth redirect; unknown authenticated path renders shell-wrapped 404 with protected CTA; Pencil-based 404 styling consumes design tokens only.
+  - Post-implementation regression: unit, browser/component, route/integration, and Playwright coverage for i18n + 404 are green, and `pnpm complete-check` passes.

--- a/drizzle/0001_strange_medusa.sql
+++ b/drizzle/0001_strange_medusa.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `user` ADD `locale` text;

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,359 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "f3d2d4b3-98e0-4357-9732-3bc146d568f0",
+  "prevId": "3fbedf2b-2181-49a2-98e6-890a8ae7fe96",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": ["token"],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": ["identifier"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1781177036842,
       "tag": "0000_great_tigra",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1781339456890,
+      "tag": "0001_strange_medusa",
+      "breakpoints": true
     }
   ]
 }

--- a/e2e/tests/auth/authenticated-not-found-smoke.spec.ts
+++ b/e2e/tests/auth/authenticated-not-found-smoke.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from '../../fixtures/test';
+import { appRoutes } from '../../utils/routes';
+
+test('@smoke unknown authenticated route renders shell-wrapped localized 404 with CTA to home', async ({
+  authenticateSession,
+  page
+}) => {
+  await authenticateSession();
+
+  await page.goto(appRoutes.unknownPublic);
+
+  // Protected shell chrome must be present (shell-wrapped 404)
+  await expect(
+    page.getByRole('heading', { level: 2, name: 'Protected library shell ready' })
+  ).toBeVisible();
+  await expect(page.getByRole('button', { name: /open account menu/i })).toBeVisible();
+
+  // Localized 404 content inside shell (h2, not h1)
+  await expect(page.getByRole('heading', { level: 2, name: 'Page not found' })).toBeVisible();
+  await expect(
+    page.getByText("The page you're looking for doesn't exist or has been moved.")
+  ).toBeVisible();
+
+  // CTA points to protected home /
+  const ctaLink = page.getByRole('link', { name: /go home/i });
+  await expect(ctaLink).toBeVisible();
+  await expect(ctaLink).toHaveAttribute('href', '/');
+
+  // Follow CTA — reaches protected home
+  await ctaLink.click();
+  await expect(page).toHaveURL(/\/$/);
+  await expect(
+    page.getByRole('heading', { level: 2, name: 'Protected library shell ready' })
+  ).toBeVisible();
+});

--- a/e2e/tests/locale-smoke.spec.ts
+++ b/e2e/tests/locale-smoke.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from '../fixtures/test';
+import { appRoutes } from '../utils/routes';
+
+test('@smoke signed-out locale switch persists across reload', async ({ page }) => {
+  await page.goto(appRoutes.login);
+
+  await expect(page).toHaveURL(/\/login$/);
+
+  // Open language switcher and select Português (Brasil)
+  await page.getByLabel('Language').click();
+  await page.getByRole('option', { name: 'Português (Brasil)' }).click();
+
+  // Verify Portuguese copy is visible after switch
+  await expect(page.getByText('Boas-vindas')).toBeVisible();
+  await expect(page.locator('html')).toHaveAttribute('lang', 'pt-BR');
+
+  // Reload — locale must persist from localStorage
+  await page.reload();
+
+  await expect(page).toHaveURL(/\/login$/);
+  await expect(page.getByText('Boas-vindas')).toBeVisible();
+  await expect(page.locator('html')).toHaveAttribute('lang', 'pt-BR');
+});
+
+test('@smoke authenticated profile locale switch persists across reload', async ({
+  authenticateSession,
+  page
+}) => {
+  await authenticateSession();
+
+  await page.goto(appRoutes.home);
+
+  await expect(
+    page.getByRole('heading', { level: 2, name: 'Protected library shell ready' })
+  ).toBeVisible();
+
+  await page.getByRole('button', { name: /open account menu/i }).click();
+  await page.getByLabel('Language').click();
+  await page.getByRole('option', { name: 'Português (Brasil)' }).click();
+
+  await expect(
+    page.getByRole('heading', {
+      level: 2,
+      name: 'Base de autenticação pronta para recursos de favoritos'
+    })
+  ).toBeVisible();
+  await expect(page.locator('html')).toHaveAttribute('lang', 'pt-BR');
+
+  await page.reload();
+
+  await expect(page).toHaveURL(/\/($|\?)/);
+  await expect(
+    page.getByRole('heading', {
+      level: 2,
+      name: 'Base de autenticação pronta para recursos de favoritos'
+    })
+  ).toBeVisible();
+  await expect(page.locator('html')).toHaveAttribute('lang', 'pt-BR');
+});

--- a/e2e/tests/not-found-smoke.spec.ts
+++ b/e2e/tests/not-found-smoke.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '../fixtures/test';
+import { appRoutes } from '../utils/routes';
+
+test('@smoke unknown public route renders standalone localized 404 with CTA to login', async ({
+  page
+}) => {
+  await page.goto(appRoutes.unknownPublic);
+
+  // Standalone 404 — no protected shell chrome
+  await expect(
+    page.getByRole('heading', { level: 2, name: 'Protected library shell ready' })
+  ).toHaveCount(0);
+
+  // Localized 404 content
+  await expect(page.getByRole('heading', { level: 1, name: 'Page not found' })).toBeVisible();
+  await expect(
+    page.getByText("The page you're looking for doesn't exist or has been moved.")
+  ).toBeVisible();
+
+  // CTA points to /login
+  const ctaLink = page.getByRole('link', { name: /go to login/i });
+  await expect(ctaLink).toBeVisible();
+  await expect(ctaLink).toHaveAttribute('href', '/login');
+
+  // Follow CTA — reaches login
+  await ctaLink.click();
+  await expect(page).toHaveURL(/\/login$/);
+  await expect(
+    page.getByRole('heading', { level: 1, name: /favoritable login shell/i })
+  ).toBeVisible();
+});

--- a/e2e/utils/routes.ts
+++ b/e2e/utils/routes.ts
@@ -1,4 +1,5 @@
 export const appRoutes = {
   home: '/',
-  login: '/login'
+  login: '/login',
+  unknownPublic: '/this-route-does-not-exist'
 } as const;

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "better-auth": "~1.6.16",
     "drizzle-orm": "~0.45.2",
     "i18next": "~26.3.1",
+    "pino": "~10.1.1",
     "react": "~19.2.7",
     "react-dom": "~19.2.7",
     "react-i18next": "~17.0.8"

--- a/package.json
+++ b/package.json
@@ -62,8 +62,10 @@
     "@tanstack/react-start": "~1.168.20",
     "better-auth": "~1.6.16",
     "drizzle-orm": "~0.45.2",
+    "i18next": "~26.3.1",
     "react": "~19.2.7",
-    "react-dom": "~19.2.7"
+    "react-dom": "~19.2.7",
+    "react-i18next": "~17.0.8"
   },
   "devDependencies": {
     "@commitlint/cli": "~21.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,12 +32,18 @@ importers:
       drizzle-orm:
         specifier: ~0.45.2
         version: 0.45.2(@libsql/client@0.17.3)(better-sqlite3@12.10.0)(kysely@0.29.2)
+      i18next:
+        specifier: ~26.3.1
+        version: 26.3.1(typescript@6.0.3)
       react:
         specifier: ~19.2.7
         version: 19.2.7
       react-dom:
         specifier: ~19.2.7
         version: 19.2.7(react@19.2.7)
+      react-i18next:
+        specifier: ~17.0.8
+        version: 17.0.8(i18next@26.3.1(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
     devDependencies:
       '@commitlint/cli':
         specifier: ~21.0.2
@@ -3403,6 +3409,9 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
+  html-parse-stringify@3.0.1:
+    resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
+
   html-tags@5.1.0:
     resolution: {integrity: sha512-n6l5uca7/y5joxZ3LUePhzmBFUJ+U2YWzhMa8XUTecSeSlQiZdF5XAd/Q3/WUl0VsXgUwWi8I7CNIwdI5WN1SQ==}
     engines: {node: '>=20.10'}
@@ -3415,6 +3424,14 @@ packages:
   hyperdyperid@1.2.0:
     resolution: {integrity: sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==}
     engines: {node: '>=10.18'}
+
+  i18next@26.3.1:
+    resolution: {integrity: sha512-txQqd5EULsqEh9OJqRH15aCaOuy/nLJyhw5EHCSKLKJE1aBbb3Zve2+uQIxgWhPm1QqUQoWyQBm2kfmmIrzkcQ==}
+    peerDependencies:
+      typescript: ^5 || ^6
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -3997,6 +4014,22 @@ packages:
     peerDependencies:
       react: ^19.2.7
 
+  react-i18next@17.0.8:
+    resolution: {integrity: sha512-0ooKbGLU8JXhe1zwpQUWIeXSgLPOfwJmgheWRIUpcoA0CpyabpGhayjdG+/eA5esC1AQ8h2jWpXjJfzQzeDOCw==}
+    peerDependencies:
+      i18next: '>= 26.2.0'
+      react: '>= 16.8.0'
+      react-dom: '*'
+      react-native: '*'
+      typescript: ^5 || ^6
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+      typescript:
+        optional: true
+
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
@@ -4493,6 +4526,10 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  void-elements@3.1.0:
+    resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
+    engines: {node: '>=0.10.0'}
 
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
@@ -7291,11 +7328,19 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
+  html-parse-stringify@3.0.1:
+    dependencies:
+      void-elements: 3.1.0
+
   html-tags@5.1.0: {}
 
   husky@9.1.7: {}
 
   hyperdyperid@1.2.0: {}
+
+  i18next@26.3.1(typescript@6.0.3):
+    optionalDependencies:
+      typescript: 6.0.3
 
   ieee754@1.2.1: {}
 
@@ -7958,6 +8003,17 @@ snapshots:
       react: 19.2.7
       scheduler: 0.27.0
 
+  react-i18next@17.0.8(i18next@26.3.1(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3):
+    dependencies:
+      '@babel/runtime': 7.29.7
+      html-parse-stringify: 3.0.1
+      i18next: 26.3.1(typescript@6.0.3)
+      react: 19.2.7
+      use-sync-external-store: 1.6.0(react@19.2.7)
+    optionalDependencies:
+      react-dom: 19.2.7(react@19.2.7)
+      typescript: 6.0.3
+
   react-is@17.0.2: {}
 
   react@19.2.7: {}
@@ -8488,6 +8544,8 @@ snapshots:
       jsdom: 29.1.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - msw
+
+  void-elements@3.1.0: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       i18next:
         specifier: ~26.3.1
         version: 26.3.1(typescript@6.0.3)
+      pino:
+        specifier: ~10.1.1
+        version: 10.1.1
       react:
         specifier: ~19.2.7
         version: 19.2.7
@@ -2242,6 +2245,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
   '@playwright/test@1.60.0':
     resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
     engines: {node: '>=18'}
@@ -2699,6 +2705,10 @@ packages:
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
+
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -3841,6 +3851,10 @@ packages:
     resolution: {integrity: sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==}
     engines: {node: '>=12.20.0'}
 
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -3927,6 +3941,16 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  pino-abstract-transport@3.0.0:
+    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@10.1.1:
+    resolution: {integrity: sha512-3qqVfpJtRQUCAOs4rTOEwLH6mwJJ/CSAlbis8fKOiMzTtXh0HN/VLsn3UWVTJ7U8DsWmxeNon2IpGb+wORXH4g==}
+    hasBin: true
+
   playwright-core@1.60.0:
     resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
     engines: {node: '>=18'}
@@ -3977,6 +4001,9 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
@@ -4004,6 +4031,9 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -4044,6 +4074,13 @@ packages:
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
+
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
+
+  real-require@1.0.0:
+    resolution: {integrity: sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -4094,6 +4131,10 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
 
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
@@ -4189,6 +4230,9 @@ packages:
     resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
     engines: {node: '>= 18'}
 
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -4203,6 +4247,10 @@ packages:
   source-map@0.7.6:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   srvx@0.11.16:
     resolution: {integrity: sha512-bp07zRuycfTY43IjAvvTFnmnJi8ikW0VFiHwOhhYcVW/L4xQ1XY4PAd4Nuum1rsA17C39zL7x+CDhrn5AL32Rw==}
@@ -4309,6 +4357,10 @@ packages:
     engines: {node: '>=10.18'}
     peerDependencies:
       tslib: ^2
+
+  thread-stream@4.2.0:
+    resolution: {integrity: sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==}
+    engines: {node: '>=20'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -6158,6 +6210,8 @@ snapshots:
   '@oxlint/binding-win32-x64-msvc@1.68.0':
     optional: true
 
+  '@pinojs/redact@0.4.0': {}
+
   '@playwright/test@1.60.0':
     dependencies:
       playwright: 1.60.0
@@ -6667,6 +6721,8 @@ snapshots:
       js-tokens: 10.0.0
 
   astral-regex@2.0.0: {}
+
+  atomic-sleep@1.0.0: {}
 
   available-typed-arrays@1.0.7:
     dependencies:
@@ -7734,6 +7790,8 @@ snapshots:
 
   obug@2.1.2: {}
 
+  on-exit-leak-free@2.1.2: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -7912,6 +7970,26 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  pino-abstract-transport@3.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@10.1.1:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 4.2.0
+
   playwright-core@1.60.0: {}
 
   playwright@1.60.0:
@@ -7965,6 +8043,8 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  process-warning@5.0.0: {}
+
   process@0.11.10: {}
 
   promise-limit@2.7.0: {}
@@ -7989,6 +8069,8 @@ snapshots:
       side-channel: 1.1.1
 
   queue-microtask@1.2.3: {}
+
+  quick-format-unescaped@4.0.4: {}
 
   rc@1.2.8:
     dependencies:
@@ -8026,6 +8108,10 @@ snapshots:
     optional: true
 
   readdirp@5.0.0: {}
+
+  real-require@0.2.0: {}
+
+  real-require@1.0.0: {}
 
   require-from-string@2.0.2: {}
 
@@ -8082,6 +8168,8 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
+
+  safe-stable-stringify@2.5.0: {}
 
   saxes@6.0.0:
     dependencies:
@@ -8212,6 +8300,10 @@ snapshots:
 
   smol-toml@1.6.1: {}
 
+  sonic-boom@4.2.1:
+    dependencies:
+      atomic-sleep: 1.0.0
+
   source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
@@ -8222,6 +8314,8 @@ snapshots:
   source-map@0.6.1: {}
 
   source-map@0.7.6: {}
+
+  split2@4.2.0: {}
 
   srvx@0.11.16: {}
 
@@ -8381,6 +8475,10 @@ snapshots:
   thingies@2.6.0(tslib@2.8.1):
     dependencies:
       tslib: 2.8.1
+
+  thread-stream@4.2.0:
+    dependencies:
+      real-require: 1.0.0
 
   tinybench@2.9.0: {}
 

--- a/src/db/schema/auth.ts
+++ b/src/db/schema/auth.ts
@@ -1,5 +1,5 @@
 import { relations, sql } from 'drizzle-orm';
-import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { sqliteTable, text, integer, index } from 'drizzle-orm/sqlite-core';
 
 export const user = sqliteTable('user', {
   id: text('id').primaryKey(),
@@ -13,7 +13,8 @@ export const user = sqliteTable('user', {
   updatedAt: integer('updated_at', { mode: 'timestamp_ms' })
     .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
     .$onUpdate(() => /* @__PURE__ */ new Date())
-    .notNull()
+    .notNull(),
+  locale: text('locale')
 });
 
 export const session = sqliteTable(

--- a/src/features/app-shell/components/ProfileMenu.module.css
+++ b/src/features/app-shell/components/ProfileMenu.module.css
@@ -71,7 +71,8 @@
 
 .kicker,
 .menuName,
-.menuEmail {
+.menuEmail,
+.statusMessage {
   margin: 0;
 }
 
@@ -92,6 +93,16 @@
 .menuEmail {
   color: var(--color-text-secondary);
   font-size: var(--typography-font-size-base);
+}
+
+.languageSwitcher {
+  margin-top: var(--space-050);
+}
+
+.statusMessage {
+  color: var(--color-status-danger-text);
+  font-size: var(--typography-font-size-sm);
+  line-height: var(--typography-line-height-body);
 }
 
 .action {

--- a/src/features/app-shell/components/ProfileMenu.tsx
+++ b/src/features/app-shell/components/ProfileMenu.tsx
@@ -1,6 +1,10 @@
 import { Popover } from '@base-ui/react/popover';
 import type { ComponentPropsWithoutRef } from 'react';
 import { useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { LanguageSwitcher } from '@/shared/i18n/components/LanguageSwitcher';
+import { useLocale } from '@/shared/i18n/LocaleProvider';
 
 import styles from './ProfileMenu.module.css';
 
@@ -23,12 +27,15 @@ function getInitials(userName: string) {
 }
 
 export function ProfileMenu({ isSigningOut, onSignOut, userEmail, userName }: ProfileMenuProps) {
+  const { t } = useTranslation();
+  const { clearLocaleUpdateError, isUpdatingLocale, locale, localeUpdateError, setLocale } =
+    useLocale();
   const initials = useMemo(() => getInitials(userName), [userName]);
   const triggerLabel = useMemo(() => {
     const identity = userName ? `${userName} (${userEmail})` : userEmail;
 
-    return `Open account menu for ${identity}`;
-  }, [userEmail, userName]);
+    return t('profileMenu.openMenuForIdentity', { identity });
+  }, [t, userEmail, userName]);
   const renderTrigger = useCallback(
     (props: ComponentPropsWithoutRef<'button'>) => (
       <button {...props} type="button">
@@ -43,6 +50,13 @@ export function ProfileMenu({ isSigningOut, onSignOut, userEmail, userName }: Pr
     ),
     [initials, userEmail, userName]
   );
+  const handleLocaleChange = useCallback(
+    async (nextLocale: typeof locale) => {
+      clearLocaleUpdateError();
+      await setLocale(nextLocale);
+    },
+    [clearLocaleUpdateError, setLocale]
+  );
 
   return (
     <Popover.Root>
@@ -55,16 +69,28 @@ export function ProfileMenu({ isSigningOut, onSignOut, userEmail, userName }: Pr
         <Popover.Positioner align="end" side="bottom" sideOffset={12}>
           <Popover.Popup className={styles.popup}>
             <div className={styles.panel}>
-              <p className={styles.kicker}>Signed in</p>
+              <p className={styles.kicker}>{t('profileMenu.signedIn')}</p>
               <p className={styles.menuName}>{userName}</p>
               <p className={styles.menuEmail}>{userEmail}</p>
+              <LanguageSwitcher
+                align="end"
+                className={styles.languageSwitcher}
+                disabled={isUpdatingLocale}
+                locale={locale}
+                onLocaleChange={handleLocaleChange}
+              />
+              {localeUpdateError ? (
+                <output aria-live="polite" className={styles.statusMessage}>
+                  {t('appShell.localeSaveError')}
+                </output>
+              ) : null}
               <button
                 className={styles.action}
                 disabled={isSigningOut}
                 onClick={onSignOut}
                 type="button"
               >
-                {isSigningOut ? 'Signing out…' : 'Sign out'}
+                {isSigningOut ? t('profileMenu.signingOut') : t('profileMenu.signOut')}
               </button>
             </div>
           </Popover.Popup>

--- a/src/features/app-shell/views/ProtectedAppShell.tsx
+++ b/src/features/app-shell/views/ProtectedAppShell.tsx
@@ -1,12 +1,12 @@
 import type { ReactNode } from 'react';
 import { useCallback, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useNavigate } from '@tanstack/react-router';
 
+import { ProfileMenu } from '@/features/app-shell/components/ProfileMenu';
 import { getBrowserAuthClient } from '@/features/auth/lib/auth-client';
-import { signOutErrorMessage } from '@/features/auth/lib/auth-defaults';
 import { ThemeToggle } from '@/shared/theme/ThemeToggle';
 
-import { ProfileMenu } from '../components/ProfileMenu';
 import styles from './ProtectedAppShell.module.css';
 
 type ProtectedAppShellProps = {
@@ -16,6 +16,7 @@ type ProtectedAppShellProps = {
 };
 
 export function ProtectedAppShell({ children, userEmail, userName }: ProtectedAppShellProps) {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const signOutRequestRef = useRef(false);
   const [isSigningOut, setIsSigningOut] = useState(false);
@@ -34,24 +35,24 @@ export function ProtectedAppShell({ children, userEmail, userName }: ProtectedAp
       const result = await getBrowserAuthClient().signOut();
 
       if (result?.error) {
-        setSignOutError(result.error.message || signOutErrorMessage);
+        setSignOutError(result.error.message || t('appShell.signOutError'));
         return;
       }
 
       await navigate({ to: '/login' });
     } catch {
-      setSignOutError(signOutErrorMessage);
+      setSignOutError(t('appShell.signOutError'));
       return;
     } finally {
       signOutRequestRef.current = false;
       setIsSigningOut(false);
     }
-  }, [navigate]);
+  }, [navigate, t]);
 
   return (
     <div className={styles.shell}>
       <a className={styles.skipLink} href="#main-content">
-        Skip to main content
+        {t('appShell.skipToMainContent')}
       </a>
       <aside className={styles.sidebar}>
         <div className={styles.sidebarBrand}>
@@ -59,32 +60,30 @@ export function ProtectedAppShell({ children, userEmail, userName }: ProtectedAp
             F
           </span>
           <div className={styles.sidebarCopy}>
-            <p className={styles.sidebarEyebrow}>Protected route</p>
+            <p className={styles.sidebarEyebrow}>{t('appShell.sidebar.eyebrow')}</p>
             <h1 className={styles.sidebarTitle}>Favoritable</h1>
           </div>
         </div>
 
-        <nav aria-label="Shell sections" className={styles.sidebarNav}>
-          <span className={`${styles.sidebarItem} ${styles.sidebarItemActive}`}>Library shell</span>
-          <span className={styles.sidebarItem}>Collections later</span>
-          <span className={styles.sidebarItem}>Settings later</span>
+        <nav aria-label={t('appShell.sidebar.navLabel')} className={styles.sidebarNav}>
+          <span className={`${styles.sidebarItem} ${styles.sidebarItemActive}`}>
+            {t('appShell.sidebar.activeSection')}
+          </span>
+          <span className={styles.sidebarItem}>{t('appShell.sidebar.collections')}</span>
+          <span className={styles.sidebarItem}>{t('appShell.sidebar.settings')}</span>
         </nav>
 
-        <p className={styles.sidebarFootnote}>
-          Empty app chrome only. Bookmark workflows land in later child tasks.
-        </p>
+        <p className={styles.sidebarFootnote}>{t('appShell.sidebar.footnote')}</p>
       </aside>
 
       <div className={styles.mainColumn}>
         <header className={styles.header}>
           <div className={styles.headerCopy}>
-            <p className={styles.headerEyebrow}>Theme shell</p>
-            <h2 className={styles.headerTitle}>Protected library shell ready</h2>
-            <p className={styles.headerCaption}>Protected shell with Better Auth session</p>
+            <p className={styles.headerEyebrow}>{t('appShell.header.eyebrow')}</p>
+            <h2 className={styles.headerTitle}>{t('appShell.header.title')}</h2>
+            <p className={styles.headerCaption}>{t('appShell.header.caption')}</p>
             <p className={styles.headerIdentity}>{`${userName} · ${userEmail}`}</p>
-            <p className={styles.headerBody}>
-              Theme persistence, profile actions, and auth redirects stay live.
-            </p>
+            <p className={styles.headerBody}>{t('appShell.header.body')}</p>
           </div>
 
           <div className={styles.headerActions}>

--- a/src/features/app-shell/views/ProtectedHomePage.tsx
+++ b/src/features/app-shell/views/ProtectedHomePage.tsx
@@ -1,24 +1,25 @@
+import { useTranslation } from 'react-i18next';
+
 import styles from './ProtectedHomePage.module.css';
 
 export function ProtectedHomePage() {
+  const { t } = useTranslation();
+
   return (
     <section aria-labelledby="protected-home-heading" className={styles.panel}>
-      <p className={styles.eyebrow}>Empty shell</p>
+      <p className={styles.eyebrow}>{t('home.eyebrow')}</p>
       <h2 className={styles.heading} id="protected-home-heading">
-        Auth foundation ready for bookmark features
+        {t('home.heading')}
       </h2>
-      <p className={styles.body}>
-        Google OAuth, persisted sessions, and protected shell access now replace the placeholder
-        auth seam from FAV-21.
-      </p>
+      <p className={styles.body}>{t('home.body')}</p>
       <div className={styles.statusRow}>
         <div className={styles.statusCard}>
-          <span className={styles.statusLabel}>Session</span>
-          <strong className={styles.statusValue}>Protected</strong>
+          <span className={styles.statusLabel}>{t('home.status.session')}</span>
+          <strong className={styles.statusValue}>{t('home.status.protected')}</strong>
         </div>
         <div className={styles.statusCard}>
-          <span className={styles.statusLabel}>Theme</span>
-          <strong className={styles.statusValue}>Persisted runtime toggle</strong>
+          <span className={styles.statusLabel}>{t('home.status.theme')}</span>
+          <strong className={styles.statusValue}>{t('home.status.themeValue')}</strong>
         </div>
       </div>
     </section>

--- a/src/features/auth/components/AuthPageHero.module.css
+++ b/src/features/auth/components/AuthPageHero.module.css
@@ -1,0 +1,230 @@
+.hero {
+  display: grid;
+  align-content: space-between;
+  gap: var(--space-125);
+  min-height: 17.5rem;
+  padding: var(--space-175);
+  background: var(--component-auth-hero-gradient);
+  color: var(--component-auth-hero-text);
+}
+
+.heroContent,
+.heroCopy,
+.heroFooter {
+  display: grid;
+}
+
+.heroContent {
+  gap: var(--space-125);
+}
+
+.heroBrand {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-100);
+}
+
+.heroBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: var(--radius-sm);
+  background: var(--component-auth-logo-surface);
+  color: var(--component-auth-logo-accent);
+  font-size: var(--typography-font-size-lg);
+  font-weight: var(--typography-font-weight-extrabold);
+}
+
+.heroLabel {
+  font-size: var(--typography-font-size-base);
+  font-weight: var(--typography-font-weight-extrabold);
+}
+
+.heroCopy {
+  gap: var(--space-125);
+}
+
+.heroHeading,
+.heroBody,
+.heroFootnote {
+  margin: 0;
+}
+
+.heroHeading {
+  font-size: var(--typography-font-size-4xl);
+  font-weight: var(--typography-font-weight-extrabold);
+  line-height: var(--typography-line-height-compact);
+}
+
+.heroBody {
+  max-width: 16.25rem;
+  font-size: var(--typography-font-size-md);
+  line-height: 1.4;
+  opacity: 0.9;
+}
+
+.heroFooter {
+  gap: var(--space-050);
+}
+
+.heroShapes {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-100);
+  min-height: 3.125rem;
+}
+
+.heroShapes span {
+  display: block;
+  background: currentcolor;
+}
+
+.shapeCircleLarge {
+  width: 2.1875rem;
+  height: 2.1875rem;
+  border-radius: var(--radius-full);
+  opacity: 0.15;
+}
+
+.shapeDiamond {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: var(--radius-md);
+  opacity: 0.1;
+  transform: rotate(45deg);
+}
+
+.shapeCircleSmall {
+  display: none;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: var(--radius-full);
+  opacity: 0.2;
+}
+
+.heroFootnote {
+  display: flex;
+  justify-content: space-between;
+  font-size: var(--typography-font-size-xs);
+  opacity: 0.7;
+}
+
+.desktopOnly {
+  display: none;
+}
+
+@media (width >= 48rem) {
+  .hero {
+    gap: var(--space-150);
+    min-height: 23.75rem;
+    padding: var(--space-225);
+  }
+
+  .heroContent {
+    gap: var(--space-150);
+  }
+
+  .heroHeading {
+    font-size: var(--typography-font-size-4xl);
+  }
+
+  .heroBody {
+    max-width: 20rem;
+    font-size: var(--typography-font-size-md);
+  }
+
+  .heroFooter {
+    gap: var(--space-075);
+  }
+
+  .heroShapes {
+    min-height: 5rem;
+    gap: var(--space-125);
+  }
+
+  .shapeCircleLarge {
+    width: 2.1875rem;
+    height: 2.1875rem;
+  }
+
+  .shapeDiamond {
+    width: 2.5rem;
+    height: 2.5rem;
+  }
+
+  .mobileOnly {
+    display: none;
+  }
+
+  .desktopOnly {
+    display: inline;
+  }
+}
+
+@media (width >= 64rem) {
+  .hero {
+    gap: var(--space-300);
+    min-height: 43.75rem;
+    padding: var(--space-300);
+  }
+
+  .heroBrand {
+    gap: var(--space-150);
+  }
+
+  .heroBadge {
+    width: 3rem;
+    height: 3rem;
+    border-radius: var(--radius-lg);
+    font-size: var(--typography-font-size-2xl);
+  }
+
+  .heroLabel {
+    font-size: var(--typography-font-size-lg);
+  }
+
+  .heroContent,
+  .heroCopy {
+    gap: var(--space-200);
+  }
+
+  .heroHeading {
+    font-size: var(--typography-font-size-5xl);
+  }
+
+  .heroBody {
+    max-width: 23.75rem;
+    font-size: var(--typography-font-size-base);
+    line-height: 1.5;
+  }
+
+  .heroFooter {
+    gap: var(--space-100);
+  }
+
+  .heroShapes {
+    min-height: 7.5rem;
+    gap: var(--space-150);
+  }
+
+  .shapeCircleLarge {
+    width: 3.75rem;
+    height: 3.75rem;
+  }
+
+  .shapeDiamond {
+    width: 5rem;
+    height: 5rem;
+    border-radius: var(--radius-2xl);
+  }
+
+  .shapeCircleSmall {
+    display: block;
+  }
+
+  .heroFootnote {
+    font-size: var(--typography-font-size-xs);
+  }
+}

--- a/src/features/auth/components/AuthPageHero.tsx
+++ b/src/features/auth/components/AuthPageHero.tsx
@@ -20,9 +20,9 @@ export function AuthPageHero() {
         </div>
 
         <div className={styles.heroCopy}>
-          <p className={styles.heroHeading} id="login-welcome">
+          <h2 className={styles.heroHeading} id="login-welcome">
             {t('auth.hero.welcome')}
-          </p>
+          </h2>
           <p className={styles.heroBody}>
             <span className={styles.mobileOnly}>{t('auth.hero.body.mobile')}</span>
             <span className={styles.desktopOnly}>{t('auth.hero.body.desktop')}</span>

--- a/src/features/auth/components/AuthPageHero.tsx
+++ b/src/features/auth/components/AuthPageHero.tsx
@@ -1,0 +1,51 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { APP_VERSION } from '@/version';
+
+import styles from './AuthPageHero.module.css';
+
+export function AuthPageHero() {
+  const { t } = useTranslation();
+  const currentYear = useMemo(() => new Date().getFullYear(), []);
+
+  return (
+    <section aria-labelledby="login-welcome" className={styles.hero}>
+      <div className={styles.heroContent}>
+        <div className={styles.heroBrand}>
+          <span aria-hidden="true" className={styles.heroBadge}>
+            F
+          </span>
+          <span className={styles.heroLabel}>Favoritable</span>
+        </div>
+
+        <div className={styles.heroCopy}>
+          <p className={styles.heroHeading} id="login-welcome">
+            {t('auth.hero.welcome')}
+          </p>
+          <p className={styles.heroBody}>
+            <span className={styles.mobileOnly}>{t('auth.hero.body.mobile')}</span>
+            <span className={styles.desktopOnly}>{t('auth.hero.body.desktop')}</span>
+          </p>
+        </div>
+      </div>
+
+      <div className={styles.heroFooter}>
+        <div aria-hidden="true" className={styles.heroShapes}>
+          <span className={styles.shapeCircleLarge} />
+          <span className={styles.shapeDiamond} />
+          <span className={styles.shapeCircleSmall} />
+        </div>
+        <p className={styles.heroFootnote}>
+          <span className={styles.mobileOnly}>
+            {t('auth.hero.footer.mobile', { year: currentYear })}
+          </span>
+          <span className={styles.desktopOnly}>
+            {t('auth.hero.footer.desktop', { year: currentYear })}
+          </span>
+          <span className={styles.desktopOnly}>{APP_VERSION}</span>
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/features/auth/components/LoginPage.module.css
+++ b/src/features/auth/components/LoginPage.module.css
@@ -33,63 +33,6 @@
   background: var(--component-auth-panel-surface);
 }
 
-.hero,
-.panel {
-  min-width: 0;
-}
-
-.hero {
-  display: grid;
-  align-content: space-between;
-  gap: var(--space-125);
-  min-height: 17.5rem;
-  padding: var(--space-175);
-  background: var(--component-auth-hero-gradient);
-  color: var(--component-auth-hero-text);
-}
-
-.heroContent,
-.heroCopy,
-.heroFooter,
-.panelContent {
-  display: grid;
-}
-
-.heroContent {
-  gap: var(--space-125);
-}
-
-.heroBrand {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-100);
-}
-
-.heroBadge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2.25rem;
-  height: 2.25rem;
-  border-radius: var(--radius-sm);
-  background: var(--component-auth-logo-surface);
-  color: var(--component-auth-logo-accent);
-  font-size: var(--typography-font-size-lg);
-  font-weight: var(--typography-font-weight-extrabold);
-}
-
-.heroLabel {
-  font-size: var(--typography-font-size-base);
-  font-weight: var(--typography-font-weight-extrabold);
-}
-
-.heroCopy {
-  gap: var(--space-125);
-}
-
-.heroHeading,
-.heroBody,
-.heroFootnote,
 .panelHeading,
 .panelBody,
 .footnote,
@@ -97,75 +40,24 @@
   margin: 0;
 }
 
-.heroHeading {
-  font-size: var(--typography-font-size-4xl);
-  font-weight: var(--typography-font-weight-extrabold);
-  line-height: var(--typography-line-height-compact);
-}
-
-.heroBody {
-  max-width: 16.25rem;
-  font-size: var(--typography-font-size-md);
-  line-height: 1.4;
-  opacity: 0.9;
-}
-
-.heroFooter {
-  gap: var(--space-050);
-}
-
-.heroShapes {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-100);
-  min-height: 3.125rem;
-}
-
-.heroShapes span {
-  display: block;
-  background: currentcolor;
-}
-
-.shapeCircleLarge {
-  width: 2.1875rem;
-  height: 2.1875rem;
-  border-radius: var(--radius-full);
-  opacity: 0.15;
-}
-
-.shapeDiamond {
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: var(--radius-md);
-  opacity: 0.1;
-  transform: rotate(45deg);
-}
-
-.shapeCircleSmall {
-  display: none;
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: var(--radius-full);
-  opacity: 0.2;
-}
-
-.heroFootnote {
-  font-size: var(--typography-font-size-xs);
-  opacity: 0.7;
-  display: flex;
-  justify-content: space-between;
-}
-
 .panel {
   display: grid;
+  min-width: 0;
+  grid-template-rows: minmax(0, 1fr) auto;
   padding: var(--space-200);
   background: var(--component-auth-panel-surface);
 }
 
 .panelContent {
+  display: grid;
+  align-self: center;
   align-content: center;
   justify-items: center;
   gap: var(--space-200);
+}
+
+.localeSwitcherCorner {
+  place-self: end;
 }
 
 .panelHeading {
@@ -216,44 +108,6 @@
     grid-template-rows: 23.75rem minmax(0, 1fr);
   }
 
-  .hero {
-    gap: var(--space-150);
-    min-height: 23.75rem;
-    padding: var(--space-225);
-  }
-
-  .heroContent {
-    gap: var(--space-150);
-  }
-
-  .heroHeading {
-    font-size: var(--typography-font-size-4xl);
-  }
-
-  .heroBody {
-    max-width: 20rem;
-    font-size: var(--typography-font-size-md);
-  }
-
-  .heroFooter {
-    gap: var(--space-075);
-  }
-
-  .heroShapes {
-    min-height: 5rem;
-    gap: var(--space-125);
-  }
-
-  .shapeCircleLarge {
-    width: 2.1875rem;
-    height: 2.1875rem;
-  }
-
-  .shapeDiamond {
-    width: 2.5rem;
-    height: 2.5rem;
-  }
-
   .panel {
     padding: var(--space-300);
   }
@@ -289,70 +143,6 @@
     min-height: 100dvh;
   }
 
-  .hero {
-    gap: var(--space-300);
-    min-height: 43.75rem;
-    padding: var(--space-300);
-  }
-
-  .heroBrand {
-    gap: var(--space-150);
-  }
-
-  .heroBadge {
-    width: 3rem;
-    height: 3rem;
-    border-radius: var(--radius-lg);
-    font-size: var(--typography-font-size-2xl);
-  }
-
-  .heroLabel {
-    font-size: var(--typography-font-size-lg);
-  }
-
-  .heroContent,
-  .heroCopy {
-    gap: var(--space-200);
-  }
-
-  .heroHeading {
-    font-size: var(--typography-font-size-5xl);
-  }
-
-  .heroBody {
-    max-width: 23.75rem;
-    font-size: var(--typography-font-size-base);
-    line-height: 1.5;
-  }
-
-  .heroFooter {
-    gap: var(--space-100);
-  }
-
-  .heroShapes {
-    min-height: 7.5rem;
-    gap: var(--space-150);
-  }
-
-  .shapeCircleLarge {
-    width: 3.75rem;
-    height: 3.75rem;
-  }
-
-  .shapeDiamond {
-    width: 5rem;
-    height: 5rem;
-    border-radius: var(--radius-2xl);
-  }
-
-  .shapeCircleSmall {
-    display: block;
-  }
-
-  .heroFootnote {
-    font-size: var(--typography-font-size-xs);
-  }
-
   .panel {
     padding: 0;
   }
@@ -360,6 +150,11 @@
   .panelContent {
     gap: var(--space-300);
     padding-inline: var(--space-300);
+  }
+
+  .localeSwitcherCorner {
+    padding-right: var(--space-300);
+    padding-bottom: var(--space-300);
   }
 
   .panelHeading {

--- a/src/features/auth/components/LoginPage.tsx
+++ b/src/features/auth/components/LoginPage.tsx
@@ -1,26 +1,38 @@
 import { useCallback, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 
-import { getBrowserAuthClient } from '../lib/auth-client';
-import { googleOAuthSetupMessage } from '../lib/auth-defaults';
-import { authProviderCopy, placeholderAuthProviderIds } from '../lib/auth-providers';
-
+import { LanguageSwitcher } from '@/shared/i18n/components/LanguageSwitcher';
+import { setLocaleHintCookie } from '@/shared/i18n/locale';
+import { useLocale } from '@/shared/i18n/LocaleProvider';
+import { AuthPageHero } from './AuthPageHero';
 import { ProviderButton } from './ProviderButton';
+import { getBrowserAuthClient } from '../lib/auth-client';
+import { googleOAuthCallbackPath } from '../lib/auth-defaults';
+import { placeholderAuthProviderIds } from '../lib/auth-providers';
 import styles from './LoginPage.module.css';
-import { APP_VERSION } from '@/version';
 
 type LoginPageProps = {
   isGoogleAuthAvailable: boolean;
 };
 
 export function LoginPage({ isGoogleAuthAvailable }: LoginPageProps) {
+  const { t } = useTranslation();
+  const { locale, setLocale } = useLocale();
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isStartingGoogleAuth, setIsStartingGoogleAuth] = useState(false);
   const isGoogleButtonDisabled = !isGoogleAuthAvailable || isStartingGoogleAuth;
   const googleButtonLabel = useMemo(
-    () => (isGoogleAuthAvailable ? undefined : 'Google OAuth unavailable'),
-    [isGoogleAuthAvailable]
+    () => (isGoogleAuthAvailable ? undefined : t('auth.googleOauthUnavailableButton')),
+    [isGoogleAuthAvailable, t]
   );
-  const currentYear = useMemo(() => new Date().getFullYear(), []);
+  const googleOAuthSetupMessage = useMemo(
+    () =>
+      t('auth.googleOauthUnavailableMessage', {
+        callbackPath: googleOAuthCallbackPath
+      }),
+    [t]
+  );
+  const soonLabel = useMemo(() => t('common.soon'), [t]);
 
   const handleGoogleSignIn = useCallback(async () => {
     if (!isGoogleAuthAvailable) {
@@ -30,6 +42,7 @@ export function LoginPage({ isGoogleAuthAvailable }: LoginPageProps) {
 
     setErrorMessage(null);
     setIsStartingGoogleAuth(true);
+    setLocaleHintCookie(locale);
 
     try {
       const response = await getBrowserAuthClient().signIn.social({
@@ -45,53 +58,14 @@ export function LoginPage({ isGoogleAuthAvailable }: LoginPageProps) {
     } finally {
       setIsStartingGoogleAuth(false);
     }
-  }, [isGoogleAuthAvailable]);
+  }, [googleOAuthSetupMessage, isGoogleAuthAvailable, locale]);
 
   return (
     <main className={styles.viewport}>
-      <h1 className={styles.srOnly}>Favoritable login shell</h1>
+      <h1 className={styles.srOnly}>{t('auth.loginShellHeading')}</h1>
 
       <div className={styles.page}>
-        <section aria-labelledby="login-welcome" className={styles.hero}>
-          <div className={styles.heroContent}>
-            <div className={styles.heroBrand}>
-              <span aria-hidden="true" className={styles.heroBadge}>
-                F
-              </span>
-              <span className={styles.heroLabel}>Favoritable</span>
-            </div>
-
-            <div className={styles.heroCopy}>
-              <p className={styles.heroHeading} id="login-welcome">
-                Welcome
-              </p>
-              <p className={styles.heroBody}>
-                <span className={styles.mobileOnly}>
-                  Save, organize, and rediscover your favorite pages.
-                </span>
-                <span className={styles.desktopOnly}>
-                  Save, organize, and rediscover your favorite pages from across the web. Your
-                  modern bookmark library awaits.
-                </span>
-              </p>
-            </div>
-          </div>
-
-          <div className={styles.heroFooter}>
-            <div aria-hidden="true" className={styles.heroShapes}>
-              <span className={styles.shapeCircleLarge} />
-              <span className={styles.shapeDiamond} />
-              <span className={styles.shapeCircleSmall} />
-            </div>
-            <p className={styles.heroFootnote}>
-              <span className={styles.mobileOnly}>© {currentYear} Favoritable</span>
-              <span className={styles.desktopOnly}>
-                © {currentYear} Favoritable. All rights reserved.
-              </span>
-              <span className={styles.desktopOnly}>{APP_VERSION}</span>
-            </p>
-          </div>
-        </section>
+        <AuthPageHero />
 
         <section aria-labelledby="login-heading" className={styles.panel}>
           <div className={styles.panelContent}>
@@ -99,8 +73,8 @@ export function LoginPage({ isGoogleAuthAvailable }: LoginPageProps) {
               Favoritable
             </h2>
             <p className={styles.panelBody}>
-              <span className={styles.mobileOnly}>Sign in to continue</span>
-              <span className={styles.desktopOnly}>Sign in to your account to continue</span>
+              <span className={styles.mobileOnly}>{t('auth.panel.body.mobile')}</span>
+              <span className={styles.desktopOnly}>{t('auth.panel.body.desktop')}</span>
             </p>
 
             <div className={styles.actions}>
@@ -111,15 +85,19 @@ export function LoginPage({ isGoogleAuthAvailable }: LoginPageProps) {
                 onClick={handleGoogleSignIn}
                 provider="google"
               />
-              {placeholderAuthProviderIds.map((provider) => (
-                <ProviderButton
-                  accessibleLabel={`${authProviderCopy[provider].label} soon`}
-                  disabled
-                  key={provider}
-                  provider={provider}
-                  badgeLabel="soon"
-                />
-              ))}
+              {placeholderAuthProviderIds.map((provider) => {
+                const providerLabel = t(`auth.providers.${provider}.label`);
+
+                return (
+                  <ProviderButton
+                    accessibleLabel={`${providerLabel} ${soonLabel.toLowerCase()}`}
+                    badgeLabel={soonLabel}
+                    disabled
+                    key={provider}
+                    provider={provider}
+                  />
+                );
+              })}
             </div>
 
             {!isGoogleAuthAvailable ? (
@@ -135,13 +113,13 @@ export function LoginPage({ isGoogleAuthAvailable }: LoginPageProps) {
             ) : null}
 
             <p className={styles.footnote}>
-              <span className={styles.mobileOnly}>
-                By signing in, you agree to our Terms and Privacy Policy
-              </span>
-              <span className={styles.desktopOnly}>
-                By signing in, you agree to our Terms of Service and Privacy Policy
-              </span>
+              <span className={styles.mobileOnly}>{t('auth.footer.mobile')}</span>
+              <span className={styles.desktopOnly}>{t('auth.footer.desktop')}</span>
             </p>
+          </div>
+
+          <div className={styles.localeSwitcherCorner}>
+            <LanguageSwitcher hideLabel locale={locale} onLocaleChange={setLocale} />
           </div>
         </section>
       </div>

--- a/src/features/auth/components/ProviderButton.tsx
+++ b/src/features/auth/components/ProviderButton.tsx
@@ -1,6 +1,7 @@
 import type { MouseEventHandler } from 'react';
+import { useTranslation } from 'react-i18next';
 
-import { authProviderCopy, type AuthProviderId } from '../lib/auth-providers';
+import { authProviderIcons, type AuthProviderId } from '../lib/auth-providers';
 
 import styles from './ProviderButton.module.css';
 
@@ -23,7 +24,7 @@ export function ProviderButton({
   onClick,
   provider
 }: ProviderButtonProps) {
-  const copy = authProviderCopy[provider];
+  const { t } = useTranslation();
   const buttonClassName = [
     styles.button,
     styles[provider],
@@ -31,7 +32,11 @@ export function ProviderButton({
   ]
     .filter(Boolean)
     .join(' ');
-  const buttonLabel = label ?? (isLoading ? copy.loadingLabel : copy.label);
+  const buttonLabel =
+    label ??
+    (isLoading
+      ? t(`auth.providers.${provider}.loadingLabel`)
+      : t(`auth.providers.${provider}.label`));
 
   return (
     <button
@@ -42,7 +47,7 @@ export function ProviderButton({
       type="button"
     >
       <span aria-hidden="true" className={styles.icon}>
-        {copy.icon}
+        {authProviderIcons[provider]}
       </span>
       <span className={styles.label}>{buttonLabel}</span>
       {badgeLabel ? (

--- a/src/features/auth/lib/auth-client.ts
+++ b/src/features/auth/lib/auth-client.ts
@@ -1,6 +1,52 @@
+import { inferAdditionalFields } from 'better-auth/client/plugins';
 import { createAuthClient } from 'better-auth/react';
 
+import type { Locale } from '@/shared/i18n/locale';
+
 import { authApiBasePath } from './auth-defaults';
+
+const localeFieldSchema = {
+  locale: {
+    type: 'string',
+    input: true,
+    required: false,
+    returned: true
+  }
+} as const;
+
+type AuthMutationResult = {
+  error?: {
+    message?: string;
+  } | null;
+};
+
+type BetterAuthUpdateUserBody = {
+  locale: Locale;
+};
+
+type BetterAuthMutationPayload = {
+  error?: {
+    message?: string;
+  } | null;
+} | null;
+
+function parseBetterAuthMutationPayload(value: unknown): BetterAuthMutationPayload {
+  if (typeof value !== 'object' || value === null) {
+    return null;
+  }
+
+  const error = Reflect.get(value, 'error');
+
+  if (typeof error !== 'object' || error === null) {
+    return {};
+  }
+
+  const message = Reflect.get(error, 'message');
+
+  return {
+    error: typeof message === 'string' ? { message } : {}
+  };
+}
 
 let browserAuthClient: ReturnType<typeof createAuthClient> | undefined;
 
@@ -19,8 +65,44 @@ export function getBrowserAuthClient() {
     baseURL: getAuthClientBaseUrl(window.location.origin),
     fetchOptions: {
       credentials: 'include'
-    }
+    },
+    plugins: [
+      inferAdditionalFields({
+        user: localeFieldSchema
+      })
+    ]
   });
 
   return browserAuthClient;
+}
+
+export async function updateBrowserUserLocale(locale: Locale): Promise<AuthMutationResult> {
+  if (typeof window === 'undefined') {
+    throw new Error('Better Auth client is browser-only. Use server auth helpers during SSR.');
+  }
+
+  // Better Auth exposes /update-user, but inferred additional field input typing does not currently
+  // flow into authClient.updateUser(...) for locale. Keep this contract isolated here until upstream
+  // client typing can own the mutation end-to-end.
+  const response = await fetch(`${getAuthClientBaseUrl(window.location.origin)}/update-user`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json'
+    },
+    credentials: 'include',
+    body: JSON.stringify({ locale } satisfies BetterAuthUpdateUserBody)
+  });
+  const payload = parseBetterAuthMutationPayload(await response.json().catch(() => null));
+
+  if (!response.ok) {
+    return {
+      error: {
+        message: payload?.error?.message || 'Locale update failed.'
+      }
+    };
+  }
+
+  return {
+    error: null
+  };
 }

--- a/src/features/auth/lib/auth-defaults.ts
+++ b/src/features/auth/lib/auth-defaults.ts
@@ -1,9 +1,7 @@
 import type { AuthProviderAvailability } from './auth-providers';
 
 export const authApiBasePath = '/api/auth';
-const googleOAuthCallbackPath = `${authApiBasePath}/callback/google`;
+export const googleOAuthCallbackPath = `${authApiBasePath}/callback/google`;
 export const unavailableAuthProviderAvailability: AuthProviderAvailability = {
   google: false
 };
-export const googleOAuthSetupMessage = `Google OAuth is unavailable. Add GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET on the server and authorize ${googleOAuthCallbackPath} in Google Cloud.`;
-export const signOutErrorMessage = 'Sign-out failed. Try again.';

--- a/src/features/auth/lib/auth-providers.ts
+++ b/src/features/auth/lib/auth-providers.ts
@@ -8,33 +8,10 @@ export type AuthProviderAvailability = {
   google: boolean;
 };
 
-export const authProviderCopy: Record<
-  AuthProviderId,
-  { icon: string; label: string; loadingLabel: string }
-> = {
-  apple: {
-    icon: '',
-    label: 'Continue with Apple',
-    loadingLabel: 'Starting Apple sign-in…'
-  },
-  facebook: {
-    icon: 'f',
-    label: 'Continue with Facebook',
-    loadingLabel: 'Starting Facebook sign-in…'
-  },
-  github: {
-    icon: 'G',
-    label: 'Continue with GitHub',
-    loadingLabel: 'Starting GitHub sign-in…'
-  },
-  google: {
-    icon: 'G',
-    label: 'Continue with Google',
-    loadingLabel: 'Starting Google sign-in…'
-  },
-  x: {
-    icon: 'X',
-    label: 'Continue with X',
-    loadingLabel: 'Starting X sign-in…'
-  }
+export const authProviderIcons: Record<AuthProviderId, string> = {
+  apple: '',
+  facebook: 'f',
+  github: 'G',
+  google: 'G',
+  x: 'X'
 };

--- a/src/features/auth/routes/route-auth.ts
+++ b/src/features/auth/routes/route-auth.ts
@@ -3,11 +3,15 @@ import { createIsomorphicFn, createServerOnlyFn } from '@tanstack/react-start';
 
 import { getBrowserAuthClient } from '../lib/auth-client';
 
-const routeAuthErrorMessage = 'Failed to load Better Auth session.';
+export const routeAuthErrorMessage = 'Failed to load Better Auth session.';
 
 type BrowserRouteAuthSessionResult = Awaited<
   ReturnType<ReturnType<typeof getBrowserAuthClient>['getSession']>
 >;
+type RouteAuthSession = Awaited<ReturnType<typeof getRouteAuthSession>>;
+type RouteAuthContext = {
+  session?: RouteAuthSession;
+};
 
 const getServerRouteAuthSession = createServerOnlyFn(async () => {
   const { getRequest } = await import('@tanstack/react-start/server');
@@ -34,8 +38,16 @@ export const getRouteAuthSession = createIsomorphicFn()
   .server(() => getServerRouteAuthSession())
   .client(async () => resolveBrowserRouteAuthSession(await getBrowserAuthClient().getSession()));
 
-export async function redirectIfLoggedOut() {
-  const session = await getRouteAuthSession();
+export function getRouteContextAuthSession(context: unknown) {
+  if (!context || typeof context !== 'object' || !('session' in context)) {
+    return undefined;
+  }
+
+  return (context as RouteAuthContext).session;
+}
+
+export async function redirectIfLoggedOut(routeAuthSession?: RouteAuthSession) {
+  const session = routeAuthSession ?? (await getRouteAuthSession());
 
   if (!session) {
     throw redirect({ to: '/login' });

--- a/src/features/auth/routes/route-auth.ts
+++ b/src/features/auth/routes/route-auth.ts
@@ -47,7 +47,7 @@ export function getRouteContextAuthSession(context: unknown) {
 }
 
 export async function redirectIfLoggedOut(routeAuthSession?: RouteAuthSession) {
-  const session = arguments.length > 0 ? routeAuthSession : await getRouteAuthSession();
+  const session = routeAuthSession === undefined ? await getRouteAuthSession() : routeAuthSession;
 
   if (!session) {
     throw redirect({ to: '/login' });

--- a/src/features/auth/routes/route-auth.ts
+++ b/src/features/auth/routes/route-auth.ts
@@ -47,7 +47,7 @@ export function getRouteContextAuthSession(context: unknown) {
 }
 
 export async function redirectIfLoggedOut(routeAuthSession?: RouteAuthSession) {
-  const session = routeAuthSession ?? (await getRouteAuthSession());
+  const session = arguments.length > 0 ? routeAuthSession : await getRouteAuthSession();
 
   if (!session) {
     throw redirect({ to: '/login' });

--- a/src/features/auth/server/auth.server.ts
+++ b/src/features/auth/server/auth.server.ts
@@ -87,7 +87,8 @@ async function repairSessionLocale(
         '[auth] Failed to repair Better Auth session locale. Returning normalized session.',
         {
           error,
-          locale
+          locale,
+          storedLocale
         }
       );
     }

--- a/src/features/auth/server/auth.server.ts
+++ b/src/features/auth/server/auth.server.ts
@@ -1,10 +1,17 @@
 import { getRequest } from '@tanstack/react-start/server';
 import { drizzleAdapter } from '@better-auth/drizzle-adapter';
 import { betterAuth } from 'better-auth';
+import { APIError } from 'better-auth/api';
 import { tanstackStartCookies } from 'better-auth/tanstack-start';
 
 import { createDb, getDb } from '@/db/client';
 import * as schema from '@/db/schema/auth';
+import {
+  defaultLocale,
+  getLocaleHintFromCookieHeader,
+  isLocale,
+  type Locale
+} from '@/shared/i18n/locale';
 import { getAuthEnvironment, hasProviderCredentials } from './env.server';
 import type { AuthEnvironment } from './env.server';
 
@@ -16,6 +23,15 @@ type CreateAuthOptions = {
   request?: Request;
 };
 
+type BetterAuthSession = Awaited<ReturnType<ReturnType<typeof createAuth>['api']['getSession']>>;
+type BaseAuthSession = NonNullable<BetterAuthSession>;
+type AuthSessionWithLocale =
+  | null
+  | (BaseAuthSession & {
+      user: BaseAuthSession['user'] & {
+        locale: Locale;
+      };
+    });
 const authInstances = new Map<string, ReturnType<typeof createAuth>>();
 
 function getConfiguredSocialProviders(authEnvironment: AuthEnvironment) {
@@ -32,6 +48,49 @@ function getConfiguredSocialProviders(authEnvironment: AuthEnvironment) {
     : undefined;
 }
 
+function getLocaleProperty(value: object) {
+  return Reflect.get(value, 'locale');
+}
+
+function resolveCanonicalLocale(
+  request: Request | null | undefined,
+  candidateLocale?: unknown,
+  fallback: Locale = defaultLocale
+) {
+  if (isLocale(candidateLocale)) {
+    return candidateLocale;
+  }
+
+  return getLocaleHintFromCookieHeader(request?.headers.get('cookie')) ?? fallback;
+}
+
+async function repairSessionLocale(
+  request: Request,
+  session: BetterAuthSession
+): Promise<AuthSessionWithLocale> {
+  if (!session) {
+    return null;
+  }
+
+  const storedLocale = getLocaleProperty(session.user);
+  const locale = resolveCanonicalLocale(request, storedLocale);
+
+  if (!isLocale(storedLocale)) {
+    await getAuth(request).api.updateUser({
+      body: { locale },
+      headers: request.headers
+    });
+  }
+
+  return {
+    ...session,
+    user: {
+      ...session.user,
+      locale
+    }
+  };
+}
+
 export function createAuth(options: CreateAuthOptions = {}) {
   const authEnvironment = options.environment ?? getAuthEnvironment(options.request);
   const database = options.environment
@@ -44,6 +103,9 @@ export function createAuth(options: CreateAuthOptions = {}) {
     secret: authEnvironment.secret,
     trustedOrigins: authEnvironment.trustedOrigins,
     advanced: {
+      ipAddress: {
+        ipAddressHeaders: ['cf-connecting-ip', 'x-forwarded-for', 'x-real-ip']
+      },
       useSecureCookies: authEnvironment.useSecureCookies
     },
     session: {
@@ -52,6 +114,50 @@ export function createAuth(options: CreateAuthOptions = {}) {
       cookieCache: {
         enabled: true,
         maxAge: 60 * 5
+      }
+    },
+    user: {
+      additionalFields: {
+        locale: {
+          type: 'string',
+          input: true,
+          required: false,
+          returned: true
+        }
+      }
+    },
+    databaseHooks: {
+      user: {
+        create: {
+          before: async (user, context) => ({
+            data: {
+              ...user,
+              locale: resolveCanonicalLocale(context?.request, getLocaleProperty(user))
+            }
+          })
+        },
+        update: {
+          before: async (user) => {
+            const locale = getLocaleProperty(user);
+
+            if (!Object.prototype.hasOwnProperty.call(user, 'locale') || locale === undefined) {
+              return undefined;
+            }
+
+            if (!isLocale(locale)) {
+              throw APIError.fromStatus('BAD_REQUEST', {
+                message: 'Unsupported locale.'
+              });
+            }
+
+            return {
+              data: {
+                ...user,
+                locale
+              }
+            };
+          }
+        }
       }
     },
     database: drizzleAdapter(database, {
@@ -72,15 +178,17 @@ export function getAuth(request?: Request) {
     return cachedAuth;
   }
 
-  const auth = createAuth({ environment: authEnvironment });
+  const authInstance = createAuth({ environment: authEnvironment });
 
-  authInstances.set(cacheKey, auth);
+  authInstances.set(cacheKey, authInstance);
 
-  return auth;
+  return authInstance;
 }
 
-export async function getServerAuthSession(request = getRequest()) {
-  return getAuth(request).api.getSession({
+export async function getServerAuthSession(request = getRequest()): Promise<AuthSessionWithLocale> {
+  const session = await getAuth(request).api.getSession({
     headers: request.headers
   });
+
+  return repairSessionLocale(request, session);
 }

--- a/src/features/auth/server/auth.server.ts
+++ b/src/features/auth/server/auth.server.ts
@@ -12,6 +12,7 @@ import {
   isLocale,
   type Locale
 } from '@/shared/i18n/locale';
+import { appLogger } from '@/shared/logging/logger';
 import { getAuthEnvironment, hasProviderCredentials } from './env.server';
 import type { AuthEnvironment } from './env.server';
 
@@ -76,10 +77,20 @@ async function repairSessionLocale(
   const locale = resolveCanonicalLocale(request, storedLocale);
 
   if (!isLocale(storedLocale)) {
-    await getAuth(request).api.updateUser({
-      body: { locale },
-      headers: request.headers
-    });
+    try {
+      await getAuth(request).api.updateUser({
+        body: { locale },
+        headers: request.headers
+      });
+    } catch (error) {
+      appLogger.warn(
+        '[auth] Failed to repair Better Auth session locale. Returning normalized session.',
+        {
+          error,
+          locale
+        }
+      );
+    }
   }
 
   return {

--- a/src/features/not-found/components/NotFoundContent.module.css
+++ b/src/features/not-found/components/NotFoundContent.module.css
@@ -113,7 +113,6 @@
 }
 
 @media (width >= 64rem) {
-  .publicFrame,
   .protectedFrame {
     padding: var(--space-175) var(--space-150);
   }

--- a/src/features/not-found/components/NotFoundContent.module.css
+++ b/src/features/not-found/components/NotFoundContent.module.css
@@ -1,0 +1,128 @@
+.protectedFrame {
+  display: grid;
+  width: 100%;
+  align-self: stretch;
+  min-height: 100%;
+  max-width: var(--layout-shell-main-card);
+  margin: 0 auto;
+  padding: var(--space-175) var(--space-150);
+  border: var(--border-width-subtle) solid var(--color-border-subtle);
+  border-radius: var(--radius-4xl);
+  background: var(--gradient-background-app);
+  box-shadow: var(--component-banner-shadow);
+  overflow: hidden;
+}
+
+.protectedViewport {
+  display: grid;
+  min-height: 100%;
+}
+
+.content {
+  --not-found-code-size: var(--typography-font-size-5xl);
+  --not-found-action-icon-size: var(--typography-font-size-base);
+
+  display: grid;
+  align-content: center;
+  justify-items: center;
+  gap: var(--space-175);
+  min-height: 100%;
+  text-align: center;
+}
+
+.publicPanelContent {
+  width: 100%;
+  gap: 0;
+}
+
+.copy {
+  display: grid;
+  gap: var(--space-175);
+}
+
+.code,
+.title,
+.description {
+  margin: 0;
+}
+
+.code {
+  color: var(--color-border-subtle);
+  font-family: var(--typography-font-family-display);
+  font-size: var(--not-found-code-size);
+  font-weight: var(--typography-font-weight-extrabold);
+  letter-spacing: -0.125rem;
+  line-height: 1;
+}
+
+.title {
+  color: var(--color-text-primary);
+  font-family: var(--typography-font-family-display);
+  font-size: var(--typography-font-size-xl);
+  font-weight: var(--typography-font-weight-extrabold);
+  line-height: var(--typography-line-height-compact);
+}
+
+.description {
+  max-width: 16.25rem;
+  color: var(--color-text-secondary);
+  font-size: var(--typography-font-size-md);
+  line-height: var(--typography-line-height-body);
+}
+
+.action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-100);
+  min-height: 2.25rem;
+  padding: var(--space-125) var(--space-175);
+  border: var(--border-width-subtle) solid var(--color-accent-primary);
+  border-radius: var(--radius-xl);
+  background: var(--gradient-brand-primary);
+  box-shadow: var(--component-banner-shadow);
+  color: var(--color-accent-primary-contrast);
+  font-size: var(--typography-font-size-base);
+  font-weight: var(--typography-font-weight-bold);
+  line-height: 1;
+  text-decoration: none;
+}
+
+.action:focus-visible {
+  outline: 0.125rem solid var(--color-text-accent);
+  outline-offset: 0.125rem;
+}
+
+.actionIcon {
+  font-size: var(--not-found-action-icon-size);
+}
+
+@media (width >= 48rem) {
+  .title {
+    font-size: var(--typography-font-size-2xl);
+  }
+
+  .description {
+    max-width: 22.5rem;
+    font-size: var(--typography-font-size-base);
+  }
+
+  .action {
+    min-height: 2.5rem;
+  }
+}
+
+@media (width >= 64rem) {
+  .publicFrame,
+  .protectedFrame {
+    padding: var(--space-175) var(--space-150);
+  }
+
+  .title {
+    font-size: var(--typography-font-size-3xl);
+  }
+
+  .description {
+    max-width: 25rem;
+  }
+}

--- a/src/features/not-found/components/NotFoundContent.tsx
+++ b/src/features/not-found/components/NotFoundContent.tsx
@@ -1,4 +1,5 @@
 import { Link } from '@tanstack/react-router';
+import { useId } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import styles from './NotFoundContent.module.css';
@@ -15,15 +16,16 @@ export function NotFoundContent({
   headingLevel = 'h1'
 }: NotFoundContentProps) {
   const { t } = useTranslation();
+  const headingId = useId();
   const Heading = headingLevel;
 
   return (
-    <section aria-labelledby="not-found-heading" className={styles.content}>
+    <section aria-labelledby={headingId} className={styles.content}>
       <p aria-hidden="true" className={styles.code}>
         404
       </p>
       <div className={styles.copy}>
-        <Heading className={styles.title} id="not-found-heading">
+        <Heading className={styles.title} id={headingId}>
           {t('notFound.title')}
         </Heading>
         <p className={styles.description}>{t('notFound.description')}</p>

--- a/src/features/not-found/components/NotFoundContent.tsx
+++ b/src/features/not-found/components/NotFoundContent.tsx
@@ -1,0 +1,39 @@
+import { Link } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
+
+import styles from './NotFoundContent.module.css';
+
+type NotFoundContentProps = {
+  actionHref: '/' | '/login';
+  actionLabel: string;
+  headingLevel?: 'h1' | 'h2';
+};
+
+export function NotFoundContent({
+  actionHref,
+  actionLabel,
+  headingLevel = 'h1'
+}: NotFoundContentProps) {
+  const { t } = useTranslation();
+  const Heading = headingLevel;
+
+  return (
+    <section aria-labelledby="not-found-heading" className={styles.content}>
+      <p aria-hidden="true" className={styles.code}>
+        404
+      </p>
+      <div className={styles.copy}>
+        <Heading className={styles.title} id="not-found-heading">
+          {t('notFound.title')}
+        </Heading>
+        <p className={styles.description}>{t('notFound.description')}</p>
+      </div>
+      <Link className={styles.action} to={actionHref}>
+        <span aria-hidden="true" className={styles.actionIcon}>
+          ←
+        </span>
+        <span>{actionLabel}</span>
+      </Link>
+    </section>
+  );
+}

--- a/src/features/not-found/views/ProtectedNotFoundPage.tsx
+++ b/src/features/not-found/views/ProtectedNotFoundPage.tsx
@@ -1,0 +1,29 @@
+import { useTranslation } from 'react-i18next';
+
+import { ProtectedAppShell } from '@/features/app-shell/views/ProtectedAppShell';
+
+import { NotFoundContent } from '../components/NotFoundContent';
+import styles from '../components/NotFoundContent.module.css';
+
+type ProtectedNotFoundPageProps = {
+  userEmail: string;
+  userName: string;
+};
+
+export function ProtectedNotFoundPage({ userEmail, userName }: ProtectedNotFoundPageProps) {
+  const { t } = useTranslation();
+
+  return (
+    <ProtectedAppShell userEmail={userEmail} userName={userName}>
+      <div className={styles.protectedViewport}>
+        <div className={styles.protectedFrame}>
+          <NotFoundContent
+            actionHref="/"
+            actionLabel={t('notFound.actions.home')}
+            headingLevel="h2"
+          />
+        </div>
+      </div>
+    </ProtectedAppShell>
+  );
+}

--- a/src/features/not-found/views/PublicNotFoundPage.tsx
+++ b/src/features/not-found/views/PublicNotFoundPage.tsx
@@ -1,0 +1,32 @@
+import { useTranslation } from 'react-i18next';
+
+import { AuthPageHero } from '@/features/auth/components/AuthPageHero';
+import loginStyles from '@/features/auth/components/LoginPage.module.css';
+import { LanguageSwitcher } from '@/shared/i18n/components/LanguageSwitcher';
+import { useLocale } from '@/shared/i18n/LocaleProvider';
+
+import { NotFoundContent } from '../components/NotFoundContent';
+import styles from '../components/NotFoundContent.module.css';
+
+export function PublicNotFoundPage() {
+  const { t } = useTranslation();
+  const { locale, setLocale } = useLocale();
+
+  return (
+    <main className={loginStyles.viewport}>
+      <div className={loginStyles.page}>
+        <AuthPageHero />
+
+        <section aria-labelledby="not-found-heading" className={loginStyles.panel}>
+          <div className={`${loginStyles.panelContent} ${styles.publicPanelContent}`}>
+            <NotFoundContent actionHref="/login" actionLabel={t('notFound.actions.login')} />
+          </div>
+
+          <div className={loginStyles.localeSwitcherCorner}>
+            <LanguageSwitcher hideLabel locale={locale} onLocaleChange={setLocale} />
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/features/not-found/views/PublicNotFoundPage.tsx
+++ b/src/features/not-found/views/PublicNotFoundPage.tsx
@@ -17,7 +17,7 @@ export function PublicNotFoundPage() {
       <div className={loginStyles.page}>
         <AuthPageHero />
 
-        <section aria-labelledby="not-found-heading" className={loginStyles.panel}>
+        <div className={loginStyles.panel}>
           <div className={`${loginStyles.panelContent} ${styles.publicPanelContent}`}>
             <NotFoundContent actionHref="/login" actionLabel={t('notFound.actions.login')} />
           </div>
@@ -25,7 +25,7 @@ export function PublicNotFoundPage() {
           <div className={loginStyles.localeSwitcherCorner}>
             <LanguageSwitcher hideLabel locale={locale} onLocaleChange={setLocale} />
           </div>
-        </section>
+        </div>
       </div>
     </main>
   );

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,11 +1,36 @@
 import type { ReactNode } from 'react';
 import { HeadContent, Scripts, createRootRoute } from '@tanstack/react-router';
 
+import { getRouteAuthSession, routeAuthErrorMessage } from '@/features/auth/routes/route-auth';
+import { ProtectedNotFoundPage } from '@/features/not-found/views/ProtectedNotFoundPage';
+import { PublicNotFoundPage } from '@/features/not-found/views/PublicNotFoundPage';
+import { LocaleProvider } from '@/shared/i18n/LocaleProvider';
+import { defaultLocale, localeBootstrapScript, normalizeLocale } from '@/shared/i18n/locale';
+import { appLogger } from '@/shared/logging/logger';
 import { ThemeProvider } from '@/shared/theme/ThemeProvider';
 import { themeBootstrapScript } from '@/shared/theme/theme';
 import appCss from '@/styles.css?url';
 
+export async function loadOptionalRouteSession() {
+  try {
+    return await getRouteAuthSession();
+  } catch (error) {
+    if (error instanceof Error && error.message === routeAuthErrorMessage) {
+      appLogger.warn(
+        '[auth] Optional Better Auth session load failed. Rendering signed-out fallback.'
+      );
+      return null;
+    }
+
+    appLogger.error('[auth] Unexpected optional Better Auth session load failure.', { error });
+    return null;
+  }
+}
+
 export const Route = createRootRoute({
+  beforeLoad: async () => ({
+    session: await loadOptionalRouteSession()
+  }),
   head: () => ({
     meta: [
       {
@@ -26,24 +51,47 @@ export const Route = createRootRoute({
       }
     ]
   }),
+  notFoundComponent: RootNotFoundComponent,
   shellComponent: RootDocument
 });
 
 const themeBootstrapScriptMarkup = { __html: themeBootstrapScript };
+const localeBootstrapScriptMarkup = { __html: localeBootstrapScript };
+
+export function RootNotFoundComponent() {
+  const { session } = Route.useRouteContext();
+
+  if (session) {
+    return <ProtectedNotFoundPage userEmail={session.user.email} userName={session.user.name} />;
+  }
+
+  return <PublicNotFoundPage />;
+}
 
 function RootDocument({ children }: { children: ReactNode }) {
+  const { session } = Route.useRouteContext();
+  const isAuthenticated = Boolean(session);
+  const serverLocale = session ? normalizeLocale(session.user.locale) : defaultLocale;
+
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html
+      data-locale-locked={isAuthenticated ? 'true' : undefined}
+      lang={serverLocale}
+      suppressHydrationWarning
+    >
       <head>
         <HeadContent />
-        {/* Keep theme bootstrap inline before hydration. If CSP nonces land later, apply same nonce here. */}
+        {/* Keep bootstrap scripts inline before hydration. If CSP nonces land later, apply same nonce here. */}
         <script dangerouslySetInnerHTML={themeBootstrapScriptMarkup} />
+        <script dangerouslySetInnerHTML={localeBootstrapScriptMarkup} />
       </head>
       <body>
-        <ThemeProvider>
-          {children}
-          <Scripts />
-        </ThemeProvider>
+        <LocaleProvider isAuthenticated={isAuthenticated} serverLocale={session?.user.locale}>
+          <ThemeProvider>
+            {children}
+            <Scripts />
+          </ThemeProvider>
+        </LocaleProvider>
       </body>
     </html>
   );

--- a/src/routes/_protected.tsx
+++ b/src/routes/_protected.tsx
@@ -1,11 +1,12 @@
 import { Outlet, createFileRoute } from '@tanstack/react-router';
 
 import { ProtectedAppShell } from '@/features/app-shell/views/ProtectedAppShell';
-import { redirectIfLoggedOut } from '@/features/auth/routes/route-auth';
+import { getRouteContextAuthSession, redirectIfLoggedOut } from '@/features/auth/routes/route-auth';
 
 export const Route = createFileRoute('/_protected')({
-  beforeLoad: async () => {
-    const session = await redirectIfLoggedOut();
+  beforeLoad: async (options) => {
+    const rootSession = getRouteContextAuthSession(options?.context);
+    const session = rootSession ?? (await redirectIfLoggedOut());
 
     return { session };
   },

--- a/src/routes/_protected.tsx
+++ b/src/routes/_protected.tsx
@@ -6,7 +6,7 @@ import { getRouteContextAuthSession, redirectIfLoggedOut } from '@/features/auth
 export const Route = createFileRoute('/_protected')({
   beforeLoad: async (options) => {
     const rootSession = getRouteContextAuthSession(options?.context);
-    const session = rootSession ?? (await redirectIfLoggedOut());
+    const session = await redirectIfLoggedOut(rootSession);
 
     return { session };
   },

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -4,13 +4,13 @@ import {
   getClientAuthProviderAvailability,
   getRouteAuthProviderAvailability
 } from '@/features/auth/routes/login-route';
-import { getRouteAuthSession, redirectIfLoggedIn } from '@/features/auth/routes/route-auth';
+import { getRouteContextAuthSession, redirectIfLoggedIn } from '@/features/auth/routes/route-auth';
 
 export { getClientAuthProviderAvailability };
 
 export const Route = createFileRoute('/login')({
-  beforeLoad: async () => {
-    const routeAuthSessionPromise = getRouteAuthSession();
+  beforeLoad: async (options) => {
+    const routeAuthSessionPromise = Promise.resolve(getRouteContextAuthSession(options?.context));
     const providerAvailabilityPromise = getRouteAuthProviderAvailability();
 
     await redirectIfLoggedIn(routeAuthSessionPromise);

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -10,10 +10,15 @@ export { getClientAuthProviderAvailability };
 
 export const Route = createFileRoute('/login')({
   beforeLoad: async (options) => {
-    const routeAuthSessionPromise = Promise.resolve(getRouteContextAuthSession(options?.context));
+    const rootSession = getRouteContextAuthSession(options.context);
+    const hasRootSession = rootSession !== undefined;
     const providerAvailabilityPromise = getRouteAuthProviderAvailability();
 
-    await redirectIfLoggedIn(routeAuthSessionPromise);
+    if (hasRootSession) {
+      await redirectIfLoggedIn(Promise.resolve(rootSession));
+    } else {
+      await redirectIfLoggedIn();
+    }
 
     return {
       providerAvailability: await providerAvailabilityPromise

--- a/src/shared/i18n/LocaleProvider.tsx
+++ b/src/shared/i18n/LocaleProvider.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
+import { I18nextProvider } from 'react-i18next';
+
+import { updateBrowserUserLocale } from '@/features/auth/lib/auth-client';
+
+import { createI18nInstance } from './i18n';
+import {
+  applyDocumentLocale,
+  clearLocaleHintCookie,
+  defaultLocale,
+  normalizeLocale,
+  resolveClientLocale,
+  setStoredLocale,
+  type Locale
+} from './locale';
+
+type LocaleProviderProps = {
+  children: ReactNode;
+  isAuthenticated?: boolean;
+  serverLocale?: unknown;
+};
+
+type LocaleContextValue = {
+  clearLocaleUpdateError: () => void;
+  isAuthenticated: boolean;
+  isUpdatingLocale: boolean;
+  locale: Locale;
+  localeUpdateError: boolean;
+  setLocale: (locale: Locale) => Promise<void>;
+};
+
+const fallbackLocaleContextValue: LocaleContextValue = {
+  clearLocaleUpdateError: () => {},
+  isAuthenticated: false,
+  isUpdatingLocale: false,
+  locale: defaultLocale,
+  localeUpdateError: false,
+  setLocale: async () => {}
+};
+
+const LocaleContext = createContext<LocaleContextValue>(fallbackLocaleContextValue);
+
+export function LocaleProvider({
+  children,
+  isAuthenticated = false,
+  serverLocale
+}: LocaleProviderProps) {
+  const normalizedServerLocale = isAuthenticated ? normalizeLocale(serverLocale) : null;
+  const [locale, setLocaleState] = useState<Locale>(
+    () => normalizedServerLocale ?? resolveClientLocale()
+  );
+  const [isUpdatingLocale, setIsUpdatingLocale] = useState(false);
+  const [localeUpdateError, setLocaleUpdateError] = useState(false);
+  const confirmedLocaleRef = useRef<Locale>(normalizedServerLocale ?? defaultLocale);
+  const localeUpdateRequestIdRef = useRef(0);
+  const [i18n] = useState(() => createI18nInstance(locale));
+
+  useEffect(() => {
+    applyDocumentLocale(locale);
+    setStoredLocale(locale);
+    void i18n.changeLanguage(locale);
+  }, [i18n, locale]);
+
+  useEffect(() => {
+    if (!isAuthenticated || !normalizedServerLocale) {
+      return;
+    }
+
+    confirmedLocaleRef.current = normalizedServerLocale;
+    setStoredLocale(normalizedServerLocale);
+    clearLocaleHintCookie();
+    setLocaleState((currentLocale) =>
+      currentLocale === normalizedServerLocale ? currentLocale : normalizedServerLocale
+    );
+  }, [isAuthenticated, normalizedServerLocale]);
+
+  const clearLocaleUpdateError = useCallback(() => {
+    setLocaleUpdateError(false);
+  }, []);
+
+  const handleLocaleChange = useCallback(
+    async (nextLocale: Locale) => {
+      const normalizedLocale = normalizeLocale(nextLocale);
+
+      setLocaleUpdateError(false);
+
+      if (normalizedLocale === locale) {
+        return;
+      }
+
+      if (!isAuthenticated) {
+        setLocaleState(normalizedLocale);
+        return;
+      }
+
+      const previousConfirmedLocale = confirmedLocaleRef.current;
+      const requestId = localeUpdateRequestIdRef.current + 1;
+
+      localeUpdateRequestIdRef.current = requestId;
+      setLocaleState(normalizedLocale);
+      setIsUpdatingLocale(true);
+
+      try {
+        const response = await updateBrowserUserLocale(normalizedLocale);
+
+        if (response.error) {
+          throw new Error(response.error.message || 'Locale update failed.');
+        }
+
+        confirmedLocaleRef.current = normalizedLocale;
+      } catch {
+        if (localeUpdateRequestIdRef.current !== requestId) {
+          return;
+        }
+
+        confirmedLocaleRef.current = previousConfirmedLocale;
+        setLocaleState(previousConfirmedLocale);
+        setLocaleUpdateError(true);
+      } finally {
+        if (localeUpdateRequestIdRef.current === requestId) {
+          setIsUpdatingLocale(false);
+        }
+      }
+    },
+    [isAuthenticated, locale]
+  );
+
+  const value = useMemo(
+    () => ({
+      clearLocaleUpdateError,
+      isAuthenticated,
+      isUpdatingLocale,
+      locale,
+      localeUpdateError,
+      setLocale: handleLocaleChange
+    }),
+    [
+      clearLocaleUpdateError,
+      handleLocaleChange,
+      isAuthenticated,
+      isUpdatingLocale,
+      locale,
+      localeUpdateError
+    ]
+  );
+
+  return (
+    <LocaleContext.Provider value={value}>
+      <I18nextProvider i18n={i18n}>{children}</I18nextProvider>
+    </LocaleContext.Provider>
+  );
+}
+
+export function useLocale() {
+  return useContext(LocaleContext);
+}

--- a/src/shared/i18n/LocaleProvider.tsx
+++ b/src/shared/i18n/LocaleProvider.tsx
@@ -104,7 +104,6 @@ export function LocaleProvider({
         return;
       }
 
-      const previousConfirmedLocale = confirmedLocaleRef.current;
       const requestId = localeUpdateRequestIdRef.current + 1;
 
       localeUpdateRequestIdRef.current = requestId;
@@ -124,8 +123,9 @@ export function LocaleProvider({
           return;
         }
 
-        confirmedLocaleRef.current = previousConfirmedLocale;
-        setLocaleState(previousConfirmedLocale);
+        const rollbackLocale = confirmedLocaleRef.current;
+
+        setLocaleState(rollbackLocale);
         setLocaleUpdateError(true);
       } finally {
         if (localeUpdateRequestIdRef.current === requestId) {

--- a/src/shared/i18n/components/LanguageSwitcher.module.css
+++ b/src/shared/i18n/components/LanguageSwitcher.module.css
@@ -1,0 +1,109 @@
+.root {
+  display: grid;
+  gap: var(--space-050);
+}
+
+.label {
+  color: var(--color-text-muted);
+  font-size: var(--typography-font-size-sm);
+  font-weight: var(--typography-font-weight-semibold);
+}
+
+.labelHidden {
+  position: absolute;
+  width: 0.0625rem;
+  height: 0.0625rem;
+  padding: 0;
+  margin: -0.0625rem;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
+.trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-075);
+  min-width: 9.5rem;
+  min-height: 2.5rem;
+  padding: var(--space-075) var(--space-100);
+  border: var(--border-width-subtle) solid var(--color-border-subtle);
+  border-radius: var(--radius-full);
+  background: var(--color-background-surface);
+  color: var(--color-text-primary);
+  cursor: pointer;
+}
+
+.value,
+.itemLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-075);
+}
+
+.flag {
+  line-height: 1;
+}
+
+.trigger:focus-visible,
+.item:focus-visible {
+  outline: 0.125rem solid var(--color-accent-primary);
+  outline-offset: 0.125rem;
+}
+
+.trigger:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.icon {
+  color: var(--color-text-muted);
+  font-size: var(--typography-font-size-sm);
+}
+
+.popup {
+  z-index: 30;
+}
+
+.list {
+  display: grid;
+  min-width: 11rem;
+  padding: var(--space-050);
+  border: var(--border-width-subtle) solid var(--color-border-subtle);
+  border-radius: var(--radius-2xl);
+  background: var(--color-background-surface);
+  box-shadow: var(--shadow-elevation-sheet-light);
+}
+
+.item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-075);
+  min-height: 2.5rem;
+  padding: 0 var(--space-100);
+  border-radius: var(--radius-xl);
+  color: var(--color-text-primary);
+  cursor: pointer;
+}
+
+.item[data-highlighted],
+.item[data-selected] {
+  background: var(--color-background-surface-soft);
+}
+
+.itemText,
+.itemIndicator {
+  font-size: var(--typography-font-size-sm);
+}
+
+.itemIndicator {
+  color: var(--color-accent-primary);
+  font-weight: var(--typography-font-weight-bold);
+}
+
+:global(:root[data-theme='dark']) .list {
+  box-shadow: var(--shadow-elevation-sheet-dark);
+}

--- a/src/shared/i18n/components/LanguageSwitcher.tsx
+++ b/src/shared/i18n/components/LanguageSwitcher.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { Select } from '@base-ui/react/select';
+import { useCallback, useId } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { isLocale, localeFlags, supportedLocales, type Locale } from '../locale';
+
+import styles from './LanguageSwitcher.module.css';
+
+type LanguageSwitcherProps = {
+  align?: 'start' | 'center' | 'end';
+  className?: string;
+  disabled?: boolean;
+  hideLabel?: boolean;
+  locale: Locale;
+  onLocaleChange: (locale: Locale) => void | Promise<void>;
+};
+
+export function LanguageSwitcher({
+  align = 'end',
+  className,
+  disabled = false,
+  hideLabel = false,
+  locale,
+  onLocaleChange
+}: LanguageSwitcherProps) {
+  const { t } = useTranslation();
+  const labelId = useId();
+  const triggerClassName = className ? `${styles.root} ${className}` : styles.root;
+  const labelClassName = hideLabel ? `${styles.label} ${styles.labelHidden}` : styles.label;
+  const languageLabel = t('common.language');
+  const handleValueChange = useCallback(
+    (value: Locale | null) => {
+      if (!isLocale(value) || value === locale) {
+        return;
+      }
+
+      void onLocaleChange(value);
+    },
+    [locale, onLocaleChange]
+  );
+  const resolveDisplayLocale = useCallback(
+    (value: unknown) => (isLocale(value) ? value : locale),
+    [locale]
+  );
+
+  return (
+    <Select.Root disabled={disabled} onValueChange={handleValueChange} value={locale}>
+      <div className={triggerClassName}>
+        <span className={labelClassName} id={labelId}>
+          {languageLabel}
+        </span>
+        <Select.Trigger aria-labelledby={labelId} className={styles.trigger}>
+          <Select.Value>
+            {(value) => {
+              const displayLocale = resolveDisplayLocale(value);
+
+              return (
+                <span className={styles.value}>
+                  <span aria-hidden="true" className={styles.flag}>
+                    {localeFlags[displayLocale]}
+                  </span>
+                  <span>{t(`locale.names.${displayLocale}`)}</span>
+                </span>
+              );
+            }}
+          </Select.Value>
+          <span aria-hidden="true" className={styles.icon}>
+            ▾
+          </span>
+        </Select.Trigger>
+      </div>
+      <Select.Portal>
+        <Select.Positioner align={align} side="bottom" sideOffset={8}>
+          <Select.Popup className={styles.popup}>
+            <Select.List className={styles.list}>
+              {supportedLocales.map((supportedLocale) => (
+                <Select.Item className={styles.item} key={supportedLocale} value={supportedLocale}>
+                  <Select.ItemText className={styles.itemText}>
+                    <span className={styles.itemLabel}>
+                      <span aria-hidden="true" className={styles.flag}>
+                        {localeFlags[supportedLocale]}
+                      </span>
+                      <span>{t(`locale.names.${supportedLocale}`)}</span>
+                    </span>
+                  </Select.ItemText>
+                  <Select.ItemIndicator className={styles.itemIndicator}>✓</Select.ItemIndicator>
+                </Select.Item>
+              ))}
+            </Select.List>
+          </Select.Popup>
+        </Select.Positioner>
+      </Select.Portal>
+    </Select.Root>
+  );
+}

--- a/src/shared/i18n/i18n.ts
+++ b/src/shared/i18n/i18n.ts
@@ -1,0 +1,39 @@
+import { createInstance, type InitOptions } from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+import { defaultLocale, supportedLocales, type Locale } from './locale';
+import { en } from './resources/en';
+import { es } from './resources/es';
+import { ptBr } from './resources/pt-BR';
+
+const resources = {
+  en: {
+    translation: en
+  },
+  es: {
+    translation: es
+  },
+  'pt-BR': {
+    translation: ptBr
+  }
+} as const;
+
+export function createI18nInstance(locale: Locale = defaultLocale) {
+  const i18n = createInstance();
+  const options: InitOptions = {
+    resources,
+    lng: locale,
+    fallbackLng: defaultLocale,
+    supportedLngs: supportedLocales,
+    load: 'currentOnly',
+    initAsync: false,
+    interpolation: {
+      escapeValue: false
+    },
+    returnNull: false
+  };
+
+  void i18n.use(initReactI18next).init(options);
+
+  return i18n;
+}

--- a/src/shared/i18n/locale.ts
+++ b/src/shared/i18n/locale.ts
@@ -13,6 +13,10 @@ const localeStorageKey = 'favoritable-locale';
 const localeHintCookieName = 'favoritable-locale-hint';
 const localeHintCookieMaxAgeSeconds = 60 * 10;
 
+function getLocaleHintCookieSecureAttribute() {
+  return globalThis.location?.protocol === 'https:' ? '; Secure' : '';
+}
+
 export function isLocale(value: unknown): value is Locale {
   return value === 'en' || value === 'pt-BR' || value === 'es';
 }
@@ -110,7 +114,7 @@ export function setLocaleHintCookie(locale: Locale) {
     return;
   }
 
-  document.cookie = `${localeHintCookieName}=${encodeURIComponent(locale)}; Max-Age=${localeHintCookieMaxAgeSeconds}; Path=/; SameSite=Lax`;
+  document.cookie = `${localeHintCookieName}=${encodeURIComponent(locale)}; Max-Age=${localeHintCookieMaxAgeSeconds}; Path=/; SameSite=Lax${getLocaleHintCookieSecureAttribute()}`;
 }
 
 export function clearLocaleHintCookie() {
@@ -118,7 +122,7 @@ export function clearLocaleHintCookie() {
     return;
   }
 
-  document.cookie = `${localeHintCookieName}=; Max-Age=0; Path=/; SameSite=Lax`;
+  document.cookie = `${localeHintCookieName}=; Max-Age=0; Path=/; SameSite=Lax${getLocaleHintCookieSecureAttribute()}`;
 }
 
 export function getLocaleHintFromCookieHeader(

--- a/src/shared/i18n/locale.ts
+++ b/src/shared/i18n/locale.ts
@@ -1,0 +1,196 @@
+export const supportedLocales = ['en', 'pt-BR', 'es'] as const;
+
+export type Locale = (typeof supportedLocales)[number];
+
+export const localeFlags: Record<Locale, string> = {
+  en: '🇺🇸',
+  es: '🇪🇸',
+  'pt-BR': '🇧🇷'
+};
+
+export const defaultLocale: Locale = 'en';
+const localeStorageKey = 'favoritable-locale';
+const localeHintCookieName = 'favoritable-locale-hint';
+const localeHintCookieMaxAgeSeconds = 60 * 10;
+
+export function isLocale(value: unknown): value is Locale {
+  return value === 'en' || value === 'pt-BR' || value === 'es';
+}
+
+export function normalizeLocale(value: unknown, fallback: Locale = defaultLocale): Locale {
+  return isLocale(value) ? value : fallback;
+}
+
+export function mapBrowserLanguageToLocale(value: unknown): Locale {
+  if (typeof value !== 'string') {
+    return defaultLocale;
+  }
+
+  const normalizedValue = value.trim().toLowerCase();
+
+  if (!normalizedValue) {
+    return defaultLocale;
+  }
+
+  const baseLanguage = normalizedValue.split('-')[0];
+
+  if (baseLanguage === 'pt') {
+    return 'pt-BR';
+  }
+
+  if (baseLanguage === 'es') {
+    return 'es';
+  }
+
+  if (baseLanguage === 'en') {
+    return 'en';
+  }
+
+  return defaultLocale;
+}
+
+export function getBrowserLocale(): Locale {
+  if (typeof navigator === 'undefined') {
+    return defaultLocale;
+  }
+
+  const preferredLanguage = navigator.languages?.find(Boolean) ?? navigator.language;
+
+  return mapBrowserLanguageToLocale(preferredLanguage);
+}
+
+export function getStoredLocale(): Locale | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    const storedLocale = window.localStorage.getItem(localeStorageKey);
+
+    return isLocale(storedLocale) ? storedLocale : null;
+  } catch {
+    return null;
+  }
+}
+
+export function setStoredLocale(locale: Locale) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(localeStorageKey, locale);
+  } catch {
+    return;
+  }
+}
+
+function getDocumentLocale(): Locale | null {
+  if (typeof document === 'undefined') {
+    return null;
+  }
+
+  return isLocale(document.documentElement.lang) ? document.documentElement.lang : null;
+}
+
+export function resolveClientLocale(): Locale {
+  return getStoredLocale() ?? getDocumentLocale() ?? getBrowserLocale() ?? defaultLocale;
+}
+
+export function applyDocumentLocale(locale: Locale) {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  document.documentElement.lang = locale;
+}
+
+export function setLocaleHintCookie(locale: Locale) {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  document.cookie = `${localeHintCookieName}=${encodeURIComponent(locale)}; Max-Age=${localeHintCookieMaxAgeSeconds}; Path=/; SameSite=Lax`;
+}
+
+export function clearLocaleHintCookie() {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  document.cookie = `${localeHintCookieName}=; Max-Age=0; Path=/; SameSite=Lax`;
+}
+
+export function getLocaleHintFromCookieHeader(
+  cookieHeader: string | null | undefined
+): Locale | null {
+  if (!cookieHeader) {
+    return null;
+  }
+
+  for (const cookie of cookieHeader.split(';')) {
+    const [name, ...valueParts] = cookie.trim().split('=');
+
+    if (name !== localeHintCookieName) {
+      continue;
+    }
+
+    try {
+      const decodedValue = decodeURIComponent(valueParts.join('='));
+
+      return isLocale(decodedValue) ? decodedValue : null;
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+export const localeBootstrapScript = `(() => {
+  const storageKey = '${localeStorageKey}';
+  const root = document.documentElement;
+  const isLocale = (value) => value === 'en' || value === 'pt-BR' || value === 'es';
+  const mapLanguage = (value) => {
+    if (typeof value !== 'string') {
+      return 'en';
+    }
+
+    const normalizedValue = value.trim().toLowerCase();
+
+    if (!normalizedValue) {
+      return 'en';
+    }
+
+    const baseLanguage = normalizedValue.split('-')[0];
+
+    if (baseLanguage === 'pt') {
+      return 'pt-BR';
+    }
+
+    if (baseLanguage === 'es') {
+      return 'es';
+    }
+
+    if (baseLanguage === 'en') {
+      return 'en';
+    }
+
+    return 'en';
+  };
+
+  if (root.dataset.localeLocked === 'true' && isLocale(root.lang)) {
+    return;
+  }
+
+  try {
+    const storedLocale = window.localStorage.getItem(storageKey);
+    const locale = isLocale(storedLocale)
+      ? storedLocale
+      : mapLanguage(navigator.languages?.find(Boolean) || navigator.language);
+
+    root.lang = locale;
+  } catch {
+    root.lang = mapLanguage(navigator.languages?.find(Boolean) || navigator.language);
+  }
+})();`;

--- a/src/shared/i18n/resources/en.ts
+++ b/src/shared/i18n/resources/en.ts
@@ -1,0 +1,110 @@
+export const en = {
+  appShell: {
+    header: {
+      body: 'Theme persistence, profile actions, and auth redirects stay live.',
+      caption: 'Protected shell with Better Auth session',
+      eyebrow: 'Theme shell',
+      title: 'Protected library shell ready'
+    },
+    localeSaveError: 'Could not save language. Restored previous language.',
+    sidebar: {
+      activeSection: 'Library shell',
+      collections: 'Collections later',
+      eyebrow: 'Protected route',
+      footnote: 'Empty app chrome only. Bookmark workflows land in later child tasks.',
+      navLabel: 'Shell sections',
+      settings: 'Settings later'
+    },
+    signOutError: 'Sign-out failed. Try again.',
+    skipToMainContent: 'Skip to main content'
+  },
+  auth: {
+    footer: {
+      desktop: 'By signing in, you agree to our Terms of Service and Privacy Policy',
+      mobile: 'By signing in, you agree to our Terms and Privacy Policy'
+    },
+    googleOauthUnavailableButton: 'Google OAuth unavailable',
+    googleOauthUnavailableMessage:
+      'Google OAuth is unavailable. Add GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET on the server and authorize {{callbackPath}} in Google Cloud.',
+    hero: {
+      body: {
+        desktop:
+          'Save, organize, and rediscover your favorite pages from across the web. Your modern bookmark library awaits.',
+        mobile: 'Save, organize, and rediscover your favorite pages.'
+      },
+      footer: {
+        desktop: '© {{year}} Favoritable. All rights reserved.',
+        mobile: '© {{year}} Favoritable'
+      },
+      welcome: 'Welcome'
+    },
+    loginShellHeading: 'Favoritable login shell',
+    panel: {
+      body: {
+        desktop: 'Sign in to your account to continue',
+        mobile: 'Sign in to continue'
+      }
+    },
+    providers: {
+      apple: {
+        label: 'Continue with Apple',
+        loadingLabel: 'Starting Apple sign-in…'
+      },
+      facebook: {
+        label: 'Continue with Facebook',
+        loadingLabel: 'Starting Facebook sign-in…'
+      },
+      github: {
+        label: 'Continue with GitHub',
+        loadingLabel: 'Starting GitHub sign-in…'
+      },
+      google: {
+        label: 'Continue with Google',
+        loadingLabel: 'Starting Google sign-in…'
+      },
+      x: {
+        label: 'Continue with X',
+        loadingLabel: 'Starting X sign-in…'
+      }
+    }
+  },
+  common: {
+    language: 'Language',
+    soon: 'Soon'
+  },
+  home: {
+    body: 'Google OAuth, persisted sessions, and protected shell access now replace the placeholder auth seam from FAV-21.',
+    eyebrow: 'Empty shell',
+    heading: 'Auth foundation ready for bookmark features',
+    status: {
+      protected: 'Protected',
+      session: 'Session',
+      theme: 'Theme',
+      themeValue: 'Persisted runtime toggle'
+    }
+  },
+  notFound: {
+    actions: {
+      home: 'Go home',
+      login: 'Go to login'
+    },
+    description: "The page you're looking for doesn't exist or has been moved.",
+    title: 'Page not found'
+  },
+  locale: {
+    names: {
+      en: 'English',
+      es: 'Español',
+      'pt-BR': 'Português (Brasil)'
+    }
+  },
+  profileMenu: {
+    openMenuForIdentity: 'Open account menu for {{identity}}',
+    signedIn: 'Signed in',
+    signOut: 'Sign out',
+    signingOut: 'Signing out…'
+  },
+  theme: {
+    darkMode: 'Dark mode'
+  }
+} as const;

--- a/src/shared/i18n/resources/es.ts
+++ b/src/shared/i18n/resources/es.ts
@@ -1,0 +1,111 @@
+export const es = {
+  appShell: {
+    header: {
+      body: 'La persistencia del tema, las acciones del perfil y los redireccionamientos de autenticación siguen activos.',
+      caption: 'Shell protegida con sesión de Better Auth',
+      eyebrow: 'Shell de tema',
+      title: 'Shell protegida de la biblioteca lista'
+    },
+    localeSaveError: 'No se pudo guardar el idioma. Se restauró el idioma anterior.',
+    sidebar: {
+      activeSection: 'Shell de biblioteca',
+      collections: 'Colecciones después',
+      eyebrow: 'Ruta protegida',
+      footnote:
+        'Solo chrome vacío de la app. Los flujos de marcadores llegan en tareas hijas posteriores.',
+      navLabel: 'Secciones de la shell',
+      settings: 'Configuración después'
+    },
+    signOutError: 'Cerrar sesión falló. Intenta de nuevo.',
+    skipToMainContent: 'Saltar al contenido principal'
+  },
+  auth: {
+    footer: {
+      desktop: 'Al iniciar sesión, aceptas nuestros Términos de servicio y Política de privacidad',
+      mobile: 'Al iniciar sesión, aceptas nuestros Términos y Política de privacidad'
+    },
+    googleOauthUnavailableButton: 'Google OAuth no disponible',
+    googleOauthUnavailableMessage:
+      'Google OAuth no está disponible. Agrega GOOGLE_CLIENT_ID y GOOGLE_CLIENT_SECRET en el servidor y autoriza {{callbackPath}} en Google Cloud.',
+    hero: {
+      body: {
+        desktop:
+          'Guarda, organiza y redescubre tus páginas favoritas de toda la web. Tu biblioteca moderna de marcadores te espera.',
+        mobile: 'Guarda, organiza y redescubre tus páginas favoritas.'
+      },
+      footer: {
+        desktop: '© {{year}} Favoritable. Todos los derechos reservados.',
+        mobile: '© {{year}} Favoritable'
+      },
+      welcome: 'Bienvenido'
+    },
+    loginShellHeading: 'Shell de inicio de sesión de Favoritable',
+    panel: {
+      body: {
+        desktop: 'Inicia sesión en tu cuenta para continuar',
+        mobile: 'Inicia sesión para continuar'
+      }
+    },
+    providers: {
+      apple: {
+        label: 'Continuar con Apple',
+        loadingLabel: 'Iniciando acceso con Apple…'
+      },
+      facebook: {
+        label: 'Continuar con Facebook',
+        loadingLabel: 'Iniciando acceso con Facebook…'
+      },
+      github: {
+        label: 'Continuar con GitHub',
+        loadingLabel: 'Iniciando acceso con GitHub…'
+      },
+      google: {
+        label: 'Continuar con Google',
+        loadingLabel: 'Iniciando acceso con Google…'
+      },
+      x: {
+        label: 'Continuar con X',
+        loadingLabel: 'Iniciando acceso con X…'
+      }
+    }
+  },
+  common: {
+    language: 'Idioma',
+    soon: 'Pronto'
+  },
+  home: {
+    body: 'Google OAuth, las sesiones persistidas y el acceso a la shell protegida ahora reemplazan la costura temporal de autenticación de FAV-21.',
+    eyebrow: 'Shell vacía',
+    heading: 'Base de autenticación lista para funciones de marcadores',
+    status: {
+      protected: 'Protegida',
+      session: 'Sesión',
+      theme: 'Tema',
+      themeValue: 'Interruptor persistido en tiempo de ejecución'
+    }
+  },
+  notFound: {
+    actions: {
+      home: 'Ir al inicio',
+      login: 'Ir al acceso'
+    },
+    description: 'La página que buscas no existe o fue movida.',
+    title: 'Página no encontrada'
+  },
+  locale: {
+    names: {
+      en: 'English',
+      es: 'Español',
+      'pt-BR': 'Português (Brasil)'
+    }
+  },
+  profileMenu: {
+    openMenuForIdentity: 'Abrir menú de cuenta para {{identity}}',
+    signedIn: 'Sesión iniciada',
+    signOut: 'Cerrar sesión',
+    signingOut: 'Cerrando sesión…'
+  },
+  theme: {
+    darkMode: 'Modo oscuro'
+  }
+} as const;

--- a/src/shared/i18n/resources/pt-BR.ts
+++ b/src/shared/i18n/resources/pt-BR.ts
@@ -1,0 +1,110 @@
+export const ptBr = {
+  appShell: {
+    header: {
+      body: 'Persistência de tema, ações de perfil e redirecionamentos de autenticação seguem ativos.',
+      caption: 'Shell protegida com sessão do Better Auth',
+      eyebrow: 'Shell de tema',
+      title: 'Shell protegida da biblioteca pronta'
+    },
+    localeSaveError: 'Não foi possível salvar o idioma. Idioma anterior restaurado.',
+    sidebar: {
+      activeSection: 'Shell da biblioteca',
+      collections: 'Coleções depois',
+      eyebrow: 'Rota protegida',
+      footnote: 'Só chrome vazio do app. Fluxos de favoritos chegam em tarefas filhas futuras.',
+      navLabel: 'Seções da shell',
+      settings: 'Configurações depois'
+    },
+    signOutError: 'Falha ao sair. Tente de novo.',
+    skipToMainContent: 'Pular para o conteúdo principal'
+  },
+  auth: {
+    footer: {
+      desktop: 'Ao entrar, você concorda com nossos Termos de Serviço e Política de Privacidade',
+      mobile: 'Ao entrar, você concorda com nossos Termos e Política de Privacidade'
+    },
+    googleOauthUnavailableButton: 'Google OAuth indisponível',
+    googleOauthUnavailableMessage:
+      'Google OAuth está indisponível. Adicione GOOGLE_CLIENT_ID e GOOGLE_CLIENT_SECRET no servidor e autorize {{callbackPath}} no Google Cloud.',
+    hero: {
+      body: {
+        desktop:
+          'Salve, organize e redescubra suas páginas favoritas pela web. Sua biblioteca moderna de favoritos espera por você.',
+        mobile: 'Salve, organize e redescubra suas páginas favoritas.'
+      },
+      footer: {
+        desktop: '© {{year}} Favoritable. Todos os direitos reservados.',
+        mobile: '© {{year}} Favoritable'
+      },
+      welcome: 'Boas-vindas'
+    },
+    loginShellHeading: 'Shell de login do Favoritable',
+    panel: {
+      body: {
+        desktop: 'Entre na sua conta para continuar',
+        mobile: 'Entre para continuar'
+      }
+    },
+    providers: {
+      apple: {
+        label: 'Continuar com Apple',
+        loadingLabel: 'Iniciando entrada com Apple…'
+      },
+      facebook: {
+        label: 'Continuar com Facebook',
+        loadingLabel: 'Iniciando entrada com Facebook…'
+      },
+      github: {
+        label: 'Continuar com GitHub',
+        loadingLabel: 'Iniciando entrada com GitHub…'
+      },
+      google: {
+        label: 'Continuar com Google',
+        loadingLabel: 'Iniciando entrada com Google…'
+      },
+      x: {
+        label: 'Continuar com X',
+        loadingLabel: 'Iniciando entrada com X…'
+      }
+    }
+  },
+  common: {
+    language: 'Idioma',
+    soon: 'Em breve'
+  },
+  home: {
+    body: 'Google OAuth, sessões persistidas e acesso à shell protegida agora substituem a costura temporária de autenticação da FAV-21.',
+    eyebrow: 'Shell vazia',
+    heading: 'Base de autenticação pronta para recursos de favoritos',
+    status: {
+      protected: 'Protegida',
+      session: 'Sessão',
+      theme: 'Tema',
+      themeValue: 'Alternância persistida em runtime'
+    }
+  },
+  notFound: {
+    actions: {
+      home: 'Ir para o início',
+      login: 'Ir para o login'
+    },
+    description: 'A página que você procura não existe ou foi movida.',
+    title: 'Página não encontrada'
+  },
+  locale: {
+    names: {
+      en: 'English',
+      es: 'Español',
+      'pt-BR': 'Português (Brasil)'
+    }
+  },
+  profileMenu: {
+    openMenuForIdentity: 'Abrir menu da conta de {{identity}}',
+    signedIn: 'Sessão iniciada',
+    signOut: 'Sair',
+    signingOut: 'Saindo…'
+  },
+  theme: {
+    darkMode: 'Modo escuro'
+  }
+} as const;

--- a/src/shared/logging/logger.ts
+++ b/src/shared/logging/logger.ts
@@ -1,0 +1,19 @@
+type LogContext = Record<string, unknown>;
+
+function writeConsoleLog(method: 'warn' | 'error', message: string, context?: LogContext) {
+  if (context) {
+    console[method](message, context);
+    return;
+  }
+
+  console[method](message);
+}
+
+export const appLogger = {
+  error(message: string, context?: LogContext) {
+    writeConsoleLog('error', message, context);
+  },
+  warn(message: string, context?: LogContext) {
+    writeConsoleLog('warn', message, context);
+  }
+};

--- a/src/shared/logging/logger.ts
+++ b/src/shared/logging/logger.ts
@@ -1,19 +1,31 @@
-type LogContext = Record<string, unknown>;
+import pino from 'pino';
 
-function writeConsoleLog(method: 'warn' | 'error', message: string, context?: LogContext) {
+type LogContext = Record<string, unknown>;
+type LogLevel = 'warn' | 'error';
+
+const pinoLogger = pino({
+  base: undefined,
+  browser: {
+    asObject: true
+  },
+  level: import.meta.env.MODE === 'test' ? 'silent' : 'info',
+  name: 'favoritable'
+});
+
+function writePinoLog(level: LogLevel, message: string, context?: LogContext) {
   if (context) {
-    console[method](message, context);
+    pinoLogger[level](context, message);
     return;
   }
 
-  console[method](message);
+  pinoLogger[level](message);
 }
 
 export const appLogger = {
   error(message: string, context?: LogContext) {
-    writeConsoleLog('error', message, context);
+    writePinoLog('error', message, context);
   },
   warn(message: string, context?: LogContext) {
-    writeConsoleLog('warn', message, context);
+    writePinoLog('warn', message, context);
   }
 };

--- a/src/shared/theme/ThemeToggle.tsx
+++ b/src/shared/theme/ThemeToggle.tsx
@@ -1,10 +1,12 @@
 import { Switch } from '@base-ui/react/switch';
 import { useCallback, useId } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { useTheme } from './ThemeProvider';
 import styles from './ThemeToggle.module.css';
 
 export function ThemeToggle() {
+  const { t } = useTranslation();
   const labelId = useId();
   const { theme, setTheme } = useTheme();
   const handleCheckedChange = useCallback(
@@ -17,7 +19,7 @@ export function ThemeToggle() {
   return (
     <div className={styles.field}>
       <span className={styles.label} id={labelId}>
-        Dark mode
+        {t('theme.darkMode')}
       </span>
       <Switch.Root
         aria-labelledby={labelId}

--- a/src/test-support/TestI18nProvider.tsx
+++ b/src/test-support/TestI18nProvider.tsx
@@ -1,6 +1,13 @@
 import type { ReactNode } from 'react';
 
 import { LocaleProvider } from '@/shared/i18n/LocaleProvider';
+import {
+  applyDocumentLocale,
+  defaultLocale,
+  getStoredLocale,
+  isLocale,
+  setStoredLocale
+} from '@/shared/i18n/locale';
 
 type TestI18nProviderProps = {
   children: ReactNode;
@@ -13,6 +20,15 @@ export function TestI18nProvider({
   isAuthenticated = false,
   serverLocale
 }: TestI18nProviderProps) {
+  if (
+    !isAuthenticated &&
+    getStoredLocale() === null &&
+    (typeof document === 'undefined' || !isLocale(document.documentElement.lang))
+  ) {
+    setStoredLocale(defaultLocale);
+    applyDocumentLocale(defaultLocale);
+  }
+
   return (
     <LocaleProvider isAuthenticated={isAuthenticated} serverLocale={serverLocale}>
       {children}

--- a/src/test-support/TestI18nProvider.tsx
+++ b/src/test-support/TestI18nProvider.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 
 import { LocaleProvider } from '@/shared/i18n/LocaleProvider';
 import {
@@ -20,13 +20,25 @@ export function TestI18nProvider({
   isAuthenticated = false,
   serverLocale
 }: TestI18nProviderProps) {
-  if (
+  const shouldBootstrapLocale =
     !isAuthenticated &&
     getStoredLocale() === null &&
-    (typeof document === 'undefined' || !isLocale(document.documentElement.lang))
-  ) {
+    (typeof document === 'undefined' || !isLocale(document.documentElement.lang));
+  const [isLocaleReady, setIsLocaleReady] = useState(() => !shouldBootstrapLocale);
+
+  useEffect(() => {
+    if (!shouldBootstrapLocale) {
+      setIsLocaleReady(true);
+      return;
+    }
+
     setStoredLocale(defaultLocale);
     applyDocumentLocale(defaultLocale);
+    setIsLocaleReady(true);
+  }, [shouldBootstrapLocale]);
+
+  if (!isLocaleReady) {
+    return null;
   }
 
   return (

--- a/src/test-support/TestI18nProvider.tsx
+++ b/src/test-support/TestI18nProvider.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from 'react';
+
+import { LocaleProvider } from '@/shared/i18n/LocaleProvider';
+
+type TestI18nProviderProps = {
+  children: ReactNode;
+  isAuthenticated?: boolean;
+  serverLocale?: unknown;
+};
+
+export function TestI18nProvider({
+  children,
+  isAuthenticated = false,
+  serverLocale
+}: TestI18nProviderProps) {
+  return (
+    <LocaleProvider isAuthenticated={isAuthenticated} serverLocale={serverLocale}>
+      {children}
+    </LocaleProvider>
+  );
+}

--- a/test/features/app-shell/components/ProfileMenu.browser.test.tsx
+++ b/test/features/app-shell/components/ProfileMenu.browser.test.tsx
@@ -2,11 +2,11 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
 
 import { ProfileMenu } from '@/features/app-shell/components/ProfileMenu';
+import type { Locale } from '@/shared/i18n/locale';
 import { TestI18nProvider } from '@/test-support/TestI18nProvider';
 
 const { updateUserMock } = vi.hoisted(() => ({
-  updateUserMock:
-    vi.fn<(data: { locale: string }) => Promise<{ error?: { message?: string } | null }>>()
+  updateUserMock: vi.fn<(locale: Locale) => Promise<{ error?: { message?: string } | null }>>()
 }));
 
 vi.mock('@/features/auth/lib/auth-client', () => ({

--- a/test/features/app-shell/components/ProfileMenu.browser.test.tsx
+++ b/test/features/app-shell/components/ProfileMenu.browser.test.tsx
@@ -2,16 +2,28 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
 
 import { ProfileMenu } from '@/features/app-shell/components/ProfileMenu';
+import { TestI18nProvider } from '@/test-support/TestI18nProvider';
+
+const { updateUserMock } = vi.hoisted(() => ({
+  updateUserMock:
+    vi.fn<(data: { locale: string }) => Promise<{ error?: { message?: string } | null }>>()
+}));
+
+vi.mock('@/features/auth/lib/auth-client', () => ({
+  updateBrowserUserLocale: updateUserMock
+}));
 
 describe('ProfileMenu', () => {
   test('renders fallback initials when user name is empty', async () => {
     render(
-      <ProfileMenu
-        isSigningOut={false}
-        onSignOut={vi.fn<() => Promise<void>>().mockResolvedValue(undefined)}
-        userEmail="hello@favoritable.app"
-        userName=""
-      />
+      <TestI18nProvider isAuthenticated serverLocale="en">
+        <ProfileMenu
+          isSigningOut={false}
+          onSignOut={vi.fn<() => Promise<void>>().mockResolvedValue(undefined)}
+          userEmail="hello@favoritable.app"
+          userName=""
+        />
+      </TestI18nProvider>
     );
 
     expect(
@@ -23,12 +35,14 @@ describe('ProfileMenu', () => {
 
   test('uses account identity in the trigger accessible name', async () => {
     render(
-      <ProfileMenu
-        isSigningOut={false}
-        onSignOut={vi.fn<() => Promise<void>>().mockResolvedValue(undefined)}
-        userEmail="hello@favoritable.app"
-        userName="Thiago Mendonca"
-      />
+      <TestI18nProvider isAuthenticated serverLocale="en">
+        <ProfileMenu
+          isSigningOut={false}
+          onSignOut={vi.fn<() => Promise<void>>().mockResolvedValue(undefined)}
+          userEmail="hello@favoritable.app"
+          userName="Thiago Mendonca"
+        />
+      </TestI18nProvider>
     );
 
     expect(
@@ -38,14 +52,18 @@ describe('ProfileMenu', () => {
     ).toHaveTextContent('TM');
   });
 
-  test('shows disabled signing-out state inside the menu', async () => {
+  test('shows language switcher and disabled signing-out state inside the menu', async () => {
+    updateUserMock.mockResolvedValue({ error: null });
+
     render(
-      <ProfileMenu
-        isSigningOut
-        onSignOut={vi.fn<() => Promise<void>>().mockResolvedValue(undefined)}
-        userEmail="hello@favoritable.app"
-        userName="Thiago Mendonca"
-      />
+      <TestI18nProvider isAuthenticated serverLocale="en">
+        <ProfileMenu
+          isSigningOut
+          onSignOut={vi.fn<() => Promise<void>>().mockResolvedValue(undefined)}
+          userEmail="hello@favoritable.app"
+          userName="Thiago Mendonca"
+        />
+      </TestI18nProvider>
     );
 
     fireEvent.click(
@@ -55,5 +73,31 @@ describe('ProfileMenu', () => {
     );
 
     expect(await screen.findByRole('button', { name: 'Signing out…' })).toBeDisabled();
+    expect(screen.getByRole('combobox', { name: 'Language' })).toHaveTextContent('🇺🇸');
+    expect(screen.getByRole('combobox', { name: 'Language' })).toHaveTextContent('English');
+  });
+
+  test('reflects the authenticated locale inside the menu', async () => {
+    updateUserMock.mockResolvedValue({ error: null });
+
+    render(
+      <TestI18nProvider isAuthenticated serverLocale="es">
+        <ProfileMenu
+          isSigningOut={false}
+          onSignOut={vi.fn<() => Promise<void>>().mockResolvedValue(undefined)}
+          userEmail="hello@favoritable.app"
+          userName="Thiago Mendonca"
+        />
+      </TestI18nProvider>
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Abrir menú de cuenta para Thiago Mendonca (hello@favoritable.app)'
+      })
+    );
+
+    expect(screen.getByRole('combobox', { name: 'Idioma' })).toHaveTextContent('🇪🇸');
+    expect(screen.getByRole('combobox', { name: 'Idioma' })).toHaveTextContent('Español');
   });
 });

--- a/test/features/app-shell/views/ProtectedAppShell.browser.test.tsx
+++ b/test/features/app-shell/views/ProtectedAppShell.browser.test.tsx
@@ -2,11 +2,13 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { ProtectedAppShell } from '@/features/app-shell/views/ProtectedAppShell';
-import { signOutErrorMessage } from '@/features/auth/lib/auth-defaults';
+import { TestI18nProvider } from '@/test-support/TestI18nProvider';
 
-const { navigateMock, signOutMock } = vi.hoisted(() => ({
+const { navigateMock, signOutMock, updateUserMock } = vi.hoisted(() => ({
   signOutMock: vi.fn<() => Promise<{ error?: { message?: string } | null } | void>>(),
-  navigateMock: vi.fn<(options: { to: string }) => Promise<void>>()
+  navigateMock: vi.fn<(options: { to: string }) => Promise<void>>(),
+  updateUserMock:
+    vi.fn<(data: { locale: string }) => Promise<{ error?: { message?: string } | null }>>()
 }));
 
 vi.mock('@tanstack/react-router', async () => {
@@ -22,20 +24,25 @@ vi.mock('@tanstack/react-router', async () => {
 vi.mock('@/features/auth/lib/auth-client', () => ({
   getBrowserAuthClient: () => ({
     signOut: signOutMock
-  })
+  }),
+  updateBrowserUserLocale: updateUserMock
 }));
 
 describe('ProtectedAppShell', () => {
   beforeEach(() => {
     signOutMock.mockReset();
     navigateMock.mockReset();
+    updateUserMock.mockReset();
+    window.localStorage.clear();
   });
 
   test('renders current user details', () => {
     render(
-      <ProtectedAppShell userEmail="hello@favoritable.app" userName="Thiago">
-        <div>Protected content</div>
-      </ProtectedAppShell>
+      <TestI18nProvider isAuthenticated serverLocale="en">
+        <ProtectedAppShell userEmail="hello@favoritable.app" userName="Thiago">
+          <div>Protected content</div>
+        </ProtectedAppShell>
+      </TestI18nProvider>
     );
 
     expect(screen.getByRole('link', { name: 'Skip to main content' })).toHaveAttribute(
@@ -57,11 +64,14 @@ describe('ProtectedAppShell', () => {
         })
     );
     navigateMock.mockResolvedValue(undefined);
+    updateUserMock.mockResolvedValue({ error: null });
 
     render(
-      <ProtectedAppShell userEmail="hello@favoritable.app" userName="Thiago">
-        <div>Protected content</div>
-      </ProtectedAppShell>
+      <TestI18nProvider isAuthenticated serverLocale="en">
+        <ProtectedAppShell userEmail="hello@favoritable.app" userName="Thiago">
+          <div>Protected content</div>
+        </ProtectedAppShell>
+      </TestI18nProvider>
     );
 
     fireEvent.click(
@@ -96,11 +106,14 @@ describe('ProtectedAppShell', () => {
         message: 'Sign-out failed.'
       }
     });
+    updateUserMock.mockResolvedValue({ error: null });
 
     render(
-      <ProtectedAppShell userEmail="hello@favoritable.app" userName="Thiago">
-        <div>Protected content</div>
-      </ProtectedAppShell>
+      <TestI18nProvider isAuthenticated serverLocale="en">
+        <ProtectedAppShell userEmail="hello@favoritable.app" userName="Thiago">
+          <div>Protected content</div>
+        </ProtectedAppShell>
+      </TestI18nProvider>
     );
 
     fireEvent.click(
@@ -127,11 +140,14 @@ describe('ProtectedAppShell', () => {
 
   test('shows fallback sign-out error feedback when Better Auth throws', async () => {
     signOutMock.mockRejectedValue(new Error('network failed'));
+    updateUserMock.mockResolvedValue({ error: null });
 
     render(
-      <ProtectedAppShell userEmail="hello@favoritable.app" userName="Thiago">
-        <div>Protected content</div>
-      </ProtectedAppShell>
+      <TestI18nProvider isAuthenticated serverLocale="en">
+        <ProtectedAppShell userEmail="hello@favoritable.app" userName="Thiago">
+          <div>Protected content</div>
+        </ProtectedAppShell>
+      </TestI18nProvider>
     );
 
     fireEvent.click(
@@ -143,7 +159,7 @@ describe('ProtectedAppShell', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Sign out' }));
 
     await waitFor(() => {
-      expect(screen.getByRole('alert')).toHaveTextContent(signOutErrorMessage);
+      expect(screen.getByRole('alert')).toHaveTextContent('Sign-out failed. Try again.');
     });
 
     expect(navigateMock).not.toHaveBeenCalled();

--- a/test/features/app-shell/views/ProtectedAppShell.browser.test.tsx
+++ b/test/features/app-shell/views/ProtectedAppShell.browser.test.tsx
@@ -2,13 +2,13 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { ProtectedAppShell } from '@/features/app-shell/views/ProtectedAppShell';
+import type { Locale } from '@/shared/i18n/locale';
 import { TestI18nProvider } from '@/test-support/TestI18nProvider';
 
 const { navigateMock, signOutMock, updateUserMock } = vi.hoisted(() => ({
   signOutMock: vi.fn<() => Promise<{ error?: { message?: string } | null } | void>>(),
   navigateMock: vi.fn<(options: { to: string }) => Promise<void>>(),
-  updateUserMock:
-    vi.fn<(data: { locale: string }) => Promise<{ error?: { message?: string } | null }>>()
+  updateUserMock: vi.fn<(locale: Locale) => Promise<{ error?: { message?: string } | null }>>()
 }));
 
 vi.mock('@tanstack/react-router', async () => {

--- a/test/features/app-shell/views/ProtectedHomePage.browser.test.tsx
+++ b/test/features/app-shell/views/ProtectedHomePage.browser.test.tsx
@@ -2,10 +2,15 @@ import { render, screen } from '@testing-library/react';
 import { describe, expect, test } from 'vitest';
 
 import { ProtectedHomePage } from '@/features/app-shell/views/ProtectedHomePage';
+import { TestI18nProvider } from '@/test-support/TestI18nProvider';
 
 describe('ProtectedHomePage', () => {
   test('renders auth foundation copy', () => {
-    render(<ProtectedHomePage />);
+    render(
+      <TestI18nProvider isAuthenticated serverLocale="en">
+        <ProtectedHomePage />
+      </TestI18nProvider>
+    );
 
     expect(
       screen.getByRole('heading', { level: 2, name: 'Auth foundation ready for bookmark features' })

--- a/test/features/auth/components/LoginPage.browser.test.tsx
+++ b/test/features/auth/components/LoginPage.browser.test.tsx
@@ -42,6 +42,7 @@ describe('LoginPage', () => {
     expect(
       screen.getByRole('heading', { level: 1, name: 'Favoritable login shell' })
     ).toBeDefined();
+    expect(screen.getByRole('heading', { level: 2, name: 'Welcome' })).toBeDefined();
     expect(screen.getByRole('button', { name: 'Continue with Google' })).toBeEnabled();
     expect(screen.getByRole('button', { name: 'Continue with Facebook soon' })).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Continue with GitHub soon' })).toBeDisabled();

--- a/test/features/auth/components/LoginPage.browser.test.tsx
+++ b/test/features/auth/components/LoginPage.browser.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { LoginPage } from '@/features/auth/components/LoginPage';
-import { googleOAuthSetupMessage } from '@/features/auth/lib/auth-defaults';
+import { TestI18nProvider } from '@/test-support/TestI18nProvider';
 
 const { signInSocialMock } = vi.hoisted(() => ({
   signInSocialMock:
@@ -19,16 +19,25 @@ vi.mock('@/features/auth/lib/auth-client', () => ({
     signIn: {
       social: signInSocialMock
     }
-  })
+  }),
+  updateBrowserUserLocale:
+    vi.fn<(locale: string) => Promise<{ error?: { message?: string } | null }>>()
 }));
 
 describe('LoginPage', () => {
   beforeEach(() => {
     signInSocialMock.mockReset();
+    window.localStorage.clear();
+    document.documentElement.lang = 'en';
+    document.cookie = 'favoritable-locale-hint=; Max-Age=0; Path=/';
   });
 
   test('renders active Google action and provider placeholders when Google OAuth is configured', () => {
-    render(<LoginPage isGoogleAuthAvailable />);
+    render(
+      <TestI18nProvider>
+        <LoginPage isGoogleAuthAvailable />
+      </TestI18nProvider>
+    );
 
     expect(
       screen.getByRole('heading', { level: 1, name: 'Favoritable login shell' })
@@ -41,10 +50,57 @@ describe('LoginPage', () => {
   });
 
   test('disables and relabels Google action when OAuth credentials are missing', () => {
-    render(<LoginPage isGoogleAuthAvailable={false} />);
+    render(
+      <TestI18nProvider>
+        <LoginPage isGoogleAuthAvailable={false} />
+      </TestI18nProvider>
+    );
 
     expect(screen.getByRole('button', { name: 'Google OAuth unavailable' })).toBeDisabled();
-    expect(screen.getByRole('status')).toHaveTextContent(googleOAuthSetupMessage);
+    expect(screen.getByRole('status')).toHaveTextContent('Google OAuth is unavailable.');
+  });
+
+  test('uses the stored signed-out locale on first render', async () => {
+    window.localStorage.setItem('favoritable-locale', 'es');
+
+    render(
+      <TestI18nProvider>
+        <LoginPage isGoogleAuthAvailable />
+      </TestI18nProvider>
+    );
+
+    await waitFor(() => {
+      const localeSwitcher = screen.getByRole('combobox', { name: 'Idioma' });
+
+      expect(window.localStorage.getItem('favoritable-locale')).toBe('es');
+      expect(document.documentElement.lang).toBe('es');
+      expect(localeSwitcher).toHaveTextContent('🇪🇸');
+      expect(localeSwitcher).toHaveTextContent('Español');
+      expect(
+        screen.getByRole('heading', { level: 1, name: 'Shell de inicio de sesión de Favoritable' })
+      ).toBeDefined();
+    });
+  });
+
+  test('writes locale hint cookie before Google OAuth starts', async () => {
+    signInSocialMock.mockResolvedValue({ error: null });
+    window.localStorage.setItem('favoritable-locale', 'pt-BR');
+
+    render(
+      <TestI18nProvider>
+        <LoginPage isGoogleAuthAvailable />
+      </TestI18nProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continuar com Google' }));
+
+    await waitFor(() => {
+      expect(document.cookie).toContain('favoritable-locale-hint=pt-BR');
+      expect(signInSocialMock).toHaveBeenCalledWith({
+        callbackURL: '/',
+        provider: 'google'
+      });
+    });
   });
 
   test('shows auth setup error when Google OAuth fails', async () => {
@@ -54,7 +110,11 @@ describe('LoginPage', () => {
       }
     });
 
-    render(<LoginPage isGoogleAuthAvailable />);
+    render(
+      <TestI18nProvider>
+        <LoginPage isGoogleAuthAvailable />
+      </TestI18nProvider>
+    );
     fireEvent.click(screen.getByRole('button', { name: 'Continue with Google' }));
 
     await waitFor(() => {
@@ -65,11 +125,15 @@ describe('LoginPage', () => {
   test('shows fallback error when Google OAuth throws', async () => {
     signInSocialMock.mockRejectedValue(new Error('network failed'));
 
-    render(<LoginPage isGoogleAuthAvailable />);
+    render(
+      <TestI18nProvider>
+        <LoginPage isGoogleAuthAvailable />
+      </TestI18nProvider>
+    );
     fireEvent.click(screen.getByRole('button', { name: 'Continue with Google' }));
 
     await waitFor(() => {
-      expect(screen.getByRole('alert')).toHaveTextContent(googleOAuthSetupMessage);
+      expect(screen.getByRole('alert')).toHaveTextContent('Google OAuth is unavailable.');
     });
   });
 });

--- a/test/features/auth/components/ProviderButton.browser.test.tsx
+++ b/test/features/auth/components/ProviderButton.browser.test.tsx
@@ -1,10 +1,16 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { ProviderButton } from '@/features/auth/components/ProviderButton';
 import { TestI18nProvider } from '@/test-support/TestI18nProvider';
 
 describe('ProviderButton', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.localStorage.setItem('favoritable-locale', 'en');
+    document.documentElement.lang = 'en';
+  });
+
   test.each([
     ['google', 'Continue with Google'],
     ['facebook', 'Continue with Facebook'],

--- a/test/features/auth/components/ProviderButton.browser.test.tsx
+++ b/test/features/auth/components/ProviderButton.browser.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
 
 import { ProviderButton } from '@/features/auth/components/ProviderButton';
+import { TestI18nProvider } from '@/test-support/TestI18nProvider';
 
 describe('ProviderButton', () => {
   test.each([
@@ -10,13 +11,21 @@ describe('ProviderButton', () => {
     ['github', 'Continue with GitHub'],
     ['apple', 'Continue with Apple']
   ] as const)('renders %s provider copy', (provider, label) => {
-    render(<ProviderButton provider={provider} />);
+    render(
+      <TestI18nProvider>
+        <ProviderButton provider={provider} />
+      </TestI18nProvider>
+    );
 
     expect(screen.getByRole('button', { name: label })).toBeDefined();
   });
 
   test('shows provider-specific loading copy for Google sign-in launch', () => {
-    render(<ProviderButton isLoading provider="google" />);
+    render(
+      <TestI18nProvider>
+        <ProviderButton isLoading provider="google" />
+      </TestI18nProvider>
+    );
 
     expect(screen.getByRole('button', { name: 'Starting Google sign-in…' })).toBeDisabled();
     expect(screen.queryByText('soon')).toBeNull();
@@ -26,13 +35,15 @@ describe('ProviderButton', () => {
     const onClick = vi.fn<() => void>();
 
     render(
-      <ProviderButton
-        badgeLabel="setup required"
-        disabled
-        label="Google OAuth unavailable"
-        onClick={onClick}
-        provider="google"
-      />
+      <TestI18nProvider>
+        <ProviderButton
+          badgeLabel="setup required"
+          disabled
+          label="Google OAuth unavailable"
+          onClick={onClick}
+          provider="google"
+        />
+      </TestI18nProvider>
     );
 
     const button = screen.getByRole('button', { name: 'Google OAuth unavailable' });

--- a/test/features/auth/lib/auth-client.test.ts
+++ b/test/features/auth/lib/auth-client.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
-import { getAuthClientBaseUrl, getBrowserAuthClient } from '@/features/auth/lib/auth-client';
+import {
+  getAuthClientBaseUrl,
+  getBrowserAuthClient,
+  updateBrowserUserLocale
+} from '@/features/auth/lib/auth-client';
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -25,5 +29,81 @@ describe('auth client helpers', () => {
     expect(() => getBrowserAuthClient()).toThrow(
       'Better Auth client is browser-only. Use server auth helpers during SSR.'
     );
+  });
+
+  test('posts locale updates through Better Auth endpoint', async () => {
+    const fetchMock = vi
+      .fn<(input: string, init?: RequestInit) => Promise<Pick<Response, 'json' | 'ok'>>>()
+      .mockResolvedValue({
+        json: async () => ({ status: true }),
+        ok: true
+      });
+
+    vi.stubGlobal('window', {
+      location: {
+        origin: 'https://favoritable.app'
+      }
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(updateBrowserUserLocale('es')).resolves.toEqual({
+      error: null
+    });
+    expect(fetchMock).toHaveBeenCalledWith('https://favoritable.app/api/auth/update-user', {
+      body: JSON.stringify({ locale: 'es' }),
+      credentials: 'include',
+      headers: {
+        'content-type': 'application/json'
+      },
+      method: 'POST'
+    });
+  });
+
+  test('surfaces Better Auth locale update errors', async () => {
+    vi.stubGlobal('window', {
+      location: {
+        origin: 'https://favoritable.app'
+      }
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        json: async () => ({
+          error: {
+            message: 'Unsupported locale.'
+          }
+        }),
+        ok: false
+      })
+    );
+
+    await expect(updateBrowserUserLocale('es')).resolves.toEqual({
+      error: {
+        message: 'Unsupported locale.'
+      }
+    });
+  });
+
+  test('falls back to generic locale update error on invalid response payload', async () => {
+    vi.stubGlobal('window', {
+      location: {
+        origin: 'https://favoritable.app'
+      }
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        json: async () => {
+          throw new Error('bad json');
+        },
+        ok: false
+      })
+    );
+
+    await expect(updateBrowserUserLocale('es')).resolves.toEqual({
+      error: {
+        message: 'Locale update failed.'
+      }
+    });
   });
 });

--- a/test/features/auth/routes/route-auth.test.ts
+++ b/test/features/auth/routes/route-auth.test.ts
@@ -127,6 +127,16 @@ describe('route auth helpers', () => {
     expect(getRequestMock).not.toHaveBeenCalled();
   });
 
+  test('treats explicit null session as signed-out state without loading again', async () => {
+    await expect(redirectIfLoggedOut(null)).rejects.toMatchObject({
+      options: {
+        statusCode: 307,
+        to: '/login'
+      }
+    });
+    expect(getRequestMock).not.toHaveBeenCalled();
+  });
+
   test('redirects logged-in users back to home target', async () => {
     await expect(
       redirectIfLoggedIn(Promise.resolve({ user: { id: 'user-3' } }))

--- a/test/features/auth/routes/route-auth.test.ts
+++ b/test/features/auth/routes/route-auth.test.ts
@@ -127,6 +127,19 @@ describe('route auth helpers', () => {
     expect(getRequestMock).not.toHaveBeenCalled();
   });
 
+  test('treats explicit undefined session as load-needed state', async () => {
+    const request = new Request('https://favoritable.test', {
+      headers: { cookie: 'better-auth.session_token=token' }
+    });
+    const session = { user: { id: 'user-5' } };
+
+    getRequestMock.mockReturnValue(request);
+    getServerAuthSessionMock.mockResolvedValue(session);
+
+    await expect(redirectIfLoggedOut(undefined)).resolves.toBe(session);
+    expect(getServerAuthSessionMock).toHaveBeenCalledWith(request);
+  });
+
   test('treats explicit null session as signed-out state without loading again', async () => {
     await expect(redirectIfLoggedOut(null)).rejects.toMatchObject({
       options: {

--- a/test/features/auth/routes/route-auth.test.ts
+++ b/test/features/auth/routes/route-auth.test.ts
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import {
+  getRouteContextAuthSession,
   getRouteAuthSession,
   redirectIfLoggedIn,
   redirectIfLoggedOut,
-  resolveBrowserRouteAuthSession
+  resolveBrowserRouteAuthSession,
+  routeAuthErrorMessage
 } from '@/features/auth/routes/route-auth';
 
 const { getRequestMock, getServerAuthSessionMock } = vi.hoisted(() => ({
@@ -57,6 +59,44 @@ describe('route auth helpers', () => {
     ).toThrow('Session request failed.');
   });
 
+  test('falls back to route auth error message when client error payload has no message', () => {
+    expect(() =>
+      resolveBrowserRouteAuthSession({
+        data: null,
+        error: {
+          message: ''
+        }
+      })
+    ).toThrow(routeAuthErrorMessage);
+  });
+
+  test('returns null when client session payload has no data or error', () => {
+    expect(
+      resolveBrowserRouteAuthSession({
+        data: null,
+        error: null
+      })
+    ).toBeNull();
+  });
+
+  test.each([
+    ['missing context', undefined],
+    ['null context', null],
+    ['non-object context', 'session']
+  ])('returns undefined for %s', (_label, context) => {
+    expect(getRouteContextAuthSession(context)).toBeUndefined();
+  });
+
+  test('returns undefined when route context has no session field', () => {
+    expect(getRouteContextAuthSession({ user: { id: 'user-1' } })).toBeUndefined();
+  });
+
+  test('returns session from route context when present', () => {
+    const session = { user: { id: 'user-1' } };
+
+    expect(getRouteContextAuthSession({ session })).toBe(session);
+  });
+
   test('redirects logged-out users to login target', async () => {
     getRequestMock.mockReturnValue(new Request('https://favoritable.test'));
 
@@ -80,6 +120,13 @@ describe('route auth helpers', () => {
     await expect(redirectIfLoggedOut()).resolves.toBe(session);
   });
 
+  test('returns provided session for logged-in users without loading again', async () => {
+    const session = { user: { id: 'user-4' } };
+
+    await expect(redirectIfLoggedOut(session)).resolves.toBe(session);
+    expect(getRequestMock).not.toHaveBeenCalled();
+  });
+
   test('redirects logged-in users back to home target', async () => {
     await expect(
       redirectIfLoggedIn(Promise.resolve({ user: { id: 'user-3' } }))
@@ -93,5 +140,11 @@ describe('route auth helpers', () => {
 
   test('allows anonymous users to stay on login', async () => {
     await expect(redirectIfLoggedIn(Promise.resolve(null))).resolves.toBeNull();
+  });
+
+  test('allows anonymous users to stay on login when using default session loader', async () => {
+    getRequestMock.mockReturnValue(new Request('https://favoritable.test'));
+
+    await expect(redirectIfLoggedIn()).resolves.toBeNull();
   });
 });

--- a/test/features/auth/server/auth-bootstrap.test.ts
+++ b/test/features/auth/server/auth-bootstrap.test.ts
@@ -8,7 +8,7 @@ import { createClient } from '@libsql/client';
 import { describe, expect, test } from 'vitest';
 import { testUtils } from 'better-auth/plugins';
 
-import { createAuth } from '@/features/auth/server/auth.server';
+import { createAuth, getServerAuthSession } from '@/features/auth/server/auth.server';
 import type { AuthEnvironment } from '@/features/auth/server/env.server';
 
 type AuthTestHelpers = {
@@ -43,14 +43,17 @@ describe('auth database bootstrap', () => {
       });
 
       const authEnvironment: AuthEnvironment = {
-        baseUrl: 'http://127.0.0.1:4173',
+        baseUrl: 'http://127.0.0.1:4174',
         databaseAuthToken: undefined,
         databaseUrl,
         googleProvider: {},
         secret: 'favoritable-test-auth-secret-1234567890',
-        trustedOrigins: ['http://127.0.0.1:4173'],
+        trustedOrigins: ['http://127.0.0.1:4174'],
         useSecureCookies: false
       };
+      const previousDatabaseUrl = process.env.DATABASE_URL;
+      const previousBetterAuthUrl = process.env.BETTER_AUTH_URL;
+      const previousBetterAuthSecret = process.env.BETTER_AUTH_SECRET;
       const auth = createAuth({
         additionalPlugins: [testUtils()],
         environment: authEnvironment
@@ -75,19 +78,82 @@ describe('auth database bootstrap', () => {
       const databaseClient = createClient({ url: databaseUrl });
 
       try {
-        const [userCountResult, sessionCountResult] = await Promise.all([
+        const [userCountResult, sessionCountResult, userLocaleResult] = await Promise.all([
           databaseClient.execute('select count(*) as count from user'),
-          databaseClient.execute('select count(*) as count from session')
+          databaseClient.execute('select count(*) as count from session'),
+          databaseClient.execute("select locale from user where email = 'fresh-db@favoritable.app'")
         ]);
 
         expect(Number(userCountResult.rows[0]?.count ?? 0)).toBe(1);
         expect(Number(sessionCountResult.rows[0]?.count ?? 0)).toBe(1);
+        expect(userLocaleResult.rows[0]?.locale).toBe('en');
+
+        await auth.api.updateUser({
+          body: {
+            locale: 'es'
+          },
+          headers: login.headers
+        });
+
+        const updatedLocaleResult = await databaseClient.execute(
+          "select locale from user where email = 'fresh-db@favoritable.app'"
+        );
+
+        expect(updatedLocaleResult.rows[0]?.locale).toBe('es');
+        await expect(
+          auth.api.updateUser({
+            body: {
+              locale: 'fr-FR'
+            },
+            headers: login.headers
+          })
+        ).rejects.toBeTruthy();
+
+        await databaseClient.execute(
+          "update user set locale = 'fr-FR' where email = 'fresh-db@favoritable.app'"
+        );
+
+        process.env.DATABASE_URL = databaseUrl;
+        process.env.BETTER_AUTH_URL = authEnvironment.baseUrl;
+        process.env.BETTER_AUTH_SECRET = authEnvironment.secret;
+
+        const repairedSession = await getServerAuthSession(
+          new Request(authEnvironment.baseUrl, {
+            headers: login.headers
+          })
+        );
+        const repairedLocaleResult = await databaseClient.execute(
+          "select locale from user where email = 'fresh-db@favoritable.app'"
+        );
+
+        expect(repairedSession?.user.locale).toBe('en');
+        expect(repairedLocaleResult.rows[0]?.locale).toBe('en');
       } finally {
+        if (previousDatabaseUrl === undefined) {
+          delete process.env.DATABASE_URL;
+        } else {
+          process.env.DATABASE_URL = previousDatabaseUrl;
+        }
+
+        if (previousBetterAuthUrl === undefined) {
+          delete process.env.BETTER_AUTH_URL;
+        } else {
+          process.env.BETTER_AUTH_URL = previousBetterAuthUrl;
+        }
+
+        if (previousBetterAuthSecret === undefined) {
+          delete process.env.BETTER_AUTH_SECRET;
+        } else {
+          process.env.BETTER_AUTH_SECRET = previousBetterAuthSecret;
+        }
+
         databaseClient.close();
       }
 
       expect(sessionFromInitialAuth?.user.id).toBe(savedUser.id);
+      expect(sessionFromInitialAuth?.user.locale).toBe('en');
       expect(sessionFromFreshAuth?.user.id).toBe(savedUser.id);
+      expect(sessionFromFreshAuth?.user.locale).toBe('en');
     } finally {
       await rm(tempDirectory, { force: true, recursive: true });
     }

--- a/test/features/auth/server/auth.server.test.ts
+++ b/test/features/auth/server/auth.server.test.ts
@@ -15,4 +15,53 @@ describe('auth server', () => {
 
     await expect(getServerAuthSession(request)).resolves.toBeNull();
   });
+
+  test('seeds a new user locale from the locale hint cookie during auth user creation', async () => {
+    const authContext = await getAuth().$context;
+    const beforeCreateUserHook = Reflect.get(
+      Reflect.get(Reflect.get(authContext.options, 'databaseHooks') ?? {}, 'user') ?? {},
+      'create'
+    );
+    const runBeforeCreateUserHook = Reflect.get(beforeCreateUserHook ?? {}, 'before') as
+      | ((...args: Array<any>) => Promise<unknown>)
+      | undefined;
+
+    expect(typeof runBeforeCreateUserHook).toBe('function');
+
+    if (!runBeforeCreateUserHook) {
+      throw new Error('Expected Better Auth user create hook to exist.');
+    }
+
+    const result = await runBeforeCreateUserHook(
+      {
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        email: 'locale-seed@favoritable.app',
+        emailVerified: false,
+        id: 'locale-seed-user',
+        image: null,
+        name: 'Locale Seed User',
+        updatedAt: new Date('2026-01-01T00:00:00.000Z')
+      },
+      {
+        request: new Request('http://localhost:4000/api/auth/callback/google', {
+          headers: {
+            cookie: 'favoritable-locale-hint=es'
+          }
+        })
+      }
+    );
+
+    expect(result).toEqual({
+      data: {
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        email: 'locale-seed@favoritable.app',
+        emailVerified: false,
+        id: 'locale-seed-user',
+        image: null,
+        locale: 'es',
+        name: 'Locale Seed User',
+        updatedAt: new Date('2026-01-01T00:00:00.000Z')
+      }
+    });
+  });
 });

--- a/test/features/auth/server/auth.server.test.ts
+++ b/test/features/auth/server/auth.server.test.ts
@@ -1,8 +1,56 @@
-import { describe, expect, test } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { getAuth, getServerAuthSession } from '@/features/auth/server/auth.server';
 
+type GetSessionMock = (options: { headers: Headers }) => Promise<unknown>;
+type UpdateUserMock = (options: { body: { locale: string }; headers: Headers }) => Promise<unknown>;
+type BetterAuthMock = (options: unknown) => {
+  $context: Promise<{ options: unknown }>;
+  api: {
+    getSession: GetSessionMock;
+    updateUser: UpdateUserMock;
+  };
+  handler: () => void;
+};
+
+const { betterAuthMock, getSessionMock, updateUserMock, appLoggerWarnMock } = vi.hoisted(() => ({
+  appLoggerWarnMock: vi.fn<(message: string, context?: Record<string, unknown>) => void>(),
+  betterAuthMock: vi.fn<BetterAuthMock>(),
+  getSessionMock: vi.fn<GetSessionMock>(),
+  updateUserMock: vi.fn<UpdateUserMock>()
+}));
+
+vi.mock('better-auth', async () => {
+  const actual = await vi.importActual<typeof import('better-auth')>('better-auth');
+
+  return {
+    ...actual,
+    betterAuth: betterAuthMock.mockImplementation((options) => ({
+      $context: Promise.resolve({ options }),
+      api: {
+        getSession: getSessionMock,
+        updateUser: updateUserMock
+      },
+      handler: vi.fn<() => void>()
+    }))
+  };
+});
+
+vi.mock('@/shared/logging/logger', () => ({
+  appLogger: {
+    error: vi.fn<() => void>(),
+    warn: appLoggerWarnMock
+  }
+}));
+
 describe('auth server', () => {
+  beforeEach(() => {
+    betterAuthMock.mockClear();
+    getSessionMock.mockReset();
+    updateUserMock.mockReset();
+    appLoggerWarnMock.mockReset();
+  });
+
   test('creates a Better Auth instance on demand', () => {
     const auth = getAuth();
 
@@ -12,6 +60,8 @@ describe('auth server', () => {
 
   test('returns null without a session cookie', async () => {
     const request = new Request('http://localhost:4000/login');
+
+    getSessionMock.mockResolvedValue(null);
 
     await expect(getServerAuthSession(request)).resolves.toBeNull();
   });
@@ -63,5 +113,46 @@ describe('auth server', () => {
         updatedAt: new Date('2026-01-01T00:00:00.000Z')
       }
     });
+  });
+
+  test('returns normalized session when locale repair write fails', async () => {
+    const session = {
+      session: {
+        id: 'session-id'
+      },
+      user: {
+        email: 'locale-repair@favoritable.app',
+        id: 'locale-repair-user',
+        name: 'Locale Repair User'
+      }
+    };
+    const request = new Request('http://localhost:4000/', {
+      headers: {
+        cookie: 'favoritable-locale-hint=es'
+      }
+    });
+    const repairError = new Error('write failed');
+
+    getSessionMock.mockResolvedValue(session);
+    updateUserMock.mockRejectedValue(repairError);
+
+    await expect(getServerAuthSession(request)).resolves.toEqual({
+      ...session,
+      user: {
+        ...session.user,
+        locale: 'es'
+      }
+    });
+    expect(updateUserMock).toHaveBeenCalledWith({
+      body: { locale: 'es' },
+      headers: request.headers
+    });
+    expect(appLoggerWarnMock).toHaveBeenCalledWith(
+      '[auth] Failed to repair Better Auth session locale. Returning normalized session.',
+      {
+        error: repairError,
+        locale: 'es'
+      }
+    );
   });
 });

--- a/test/features/not-found/components/NotFoundContent.browser.test.tsx
+++ b/test/features/not-found/components/NotFoundContent.browser.test.tsx
@@ -1,0 +1,53 @@
+import type { ReactNode } from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { useTranslation } from 'react-i18next';
+
+import { NotFoundContent } from '@/features/not-found/components/NotFoundContent';
+import { TestI18nProvider } from '@/test-support/TestI18nProvider';
+
+vi.mock('@tanstack/react-router', async () => {
+  const actual =
+    await vi.importActual<typeof import('@tanstack/react-router')>('@tanstack/react-router');
+
+  return {
+    ...actual,
+    Link: ({ children, to, ...props }: { children: ReactNode; to: string }) => (
+      <a href={to} {...props}>
+        {children}
+      </a>
+    )
+  };
+});
+
+function NotFoundContentHarness() {
+  const { t } = useTranslation();
+
+  return <NotFoundContent actionHref="/login" actionLabel={t('notFound.actions.login')} />;
+}
+
+describe('NotFoundContent', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    document.documentElement.lang = 'en';
+  });
+
+  test('renders shared localized 404 copy from the active locale', async () => {
+    window.localStorage.setItem('favoritable-locale', 'pt-BR');
+
+    render(
+      <TestI18nProvider>
+        <NotFoundContentHarness />
+      </TestI18nProvider>
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { level: 1, name: 'Página não encontrada' })
+      ).toBeDefined();
+    });
+
+    expect(screen.getByText('A página que você procura não existe ou foi movida.')).toBeDefined();
+    expect(screen.getByRole('link', { name: 'Ir para o login' })).toHaveAttribute('href', '/login');
+  });
+});

--- a/test/features/not-found/components/NotFoundContent.browser.test.tsx
+++ b/test/features/not-found/components/NotFoundContent.browser.test.tsx
@@ -50,4 +50,24 @@ describe('NotFoundContent', () => {
     expect(screen.getByText('A página que você procura não existe ou foi movida.')).toBeDefined();
     expect(screen.getByRole('link', { name: 'Ir para o login' })).toHaveAttribute('href', '/login');
   });
+
+  test('generates unique heading ids for each instance', () => {
+    render(
+      <TestI18nProvider>
+        <>
+          <NotFoundContent actionHref="/" actionLabel="Go home" />
+          <NotFoundContent actionHref="/login" actionLabel="Go login" />
+        </>
+      </TestI18nProvider>
+    );
+
+    const headings = screen.getAllByRole('heading', { level: 1, name: 'Page not found' });
+    const regions = screen.getAllByRole('region', { name: 'Page not found' });
+
+    expect(headings[0]?.id).toBeTruthy();
+    expect(headings[1]?.id).toBeTruthy();
+    expect(headings[0]?.id).not.toBe(headings[1]?.id);
+    expect(regions[0]).toHaveAttribute('aria-labelledby', headings[0]?.id);
+    expect(regions[1]).toHaveAttribute('aria-labelledby', headings[1]?.id);
+  });
 });

--- a/test/routes/auth-routes.test.tsx
+++ b/test/routes/auth-routes.test.tsx
@@ -48,6 +48,7 @@ vi.mock('@/features/app-shell/views/ProtectedAppShell', () => ({
 }));
 
 vi.mock('@/features/auth/routes/route-auth', () => ({
+  getRouteContextAuthSession: (context: { session?: unknown } | undefined) => context?.session,
   getRouteAuthSession: vi.fn<() => Promise<unknown>>(async () => null),
   redirectIfLoggedIn: loginRedirectMock,
   redirectIfLoggedOut: protectedRedirectMock
@@ -145,6 +146,32 @@ describe('auth routes', () => {
     expect(loginRedirectMock).toHaveBeenCalledTimes(1);
   });
 
+  test('login route reuses root session context for redirect checks', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ google: true }), {
+        headers: { 'content-type': 'application/json' },
+        status: 200
+      })
+    );
+    const session = {
+      user: {
+        email: 'hello@favoritable.app',
+        name: 'Thiago'
+      }
+    };
+
+    await LoginRoute.options.beforeLoad?.({
+      context: { session }
+    } as never);
+
+    expect(loginRedirectMock).toHaveBeenCalledTimes(1);
+    const [routeAuthSessionPromise] = loginRedirectMock.mock.calls[0] as unknown as [
+      Promise<unknown>
+    ];
+
+    await expect(routeAuthSessionPromise).resolves.toBe(session);
+  });
+
   test('login route rejects with a real redirect for authenticated users', async () => {
     const authenticatedRedirect = redirect({ to: '/' });
 
@@ -204,6 +231,22 @@ describe('auth routes', () => {
         }
       }
     });
+  });
+
+  test('protected route reuses root session context when available', async () => {
+    const session = {
+      user: {
+        email: 'hello@favoritable.app',
+        name: 'Thiago'
+      }
+    };
+
+    await expect(
+      ProtectedRoute.options.beforeLoad?.({
+        context: { session }
+      } as never)
+    ).resolves.toEqual({ session });
+    expect(protectedRedirectMock).not.toHaveBeenCalled();
   });
 
   test('auth api route forwards GET requests to Better Auth handler', async () => {

--- a/test/routes/auth-routes.test.tsx
+++ b/test/routes/auth-routes.test.tsx
@@ -262,12 +262,29 @@ describe('auth routes', () => {
       }
     };
 
+    protectedRedirectMock.mockResolvedValueOnce(session);
+
     await expect(
       ProtectedRoute.options.beforeLoad?.({
         context: { session }
       } as never)
     ).resolves.toEqual({ session });
-    expect(protectedRedirectMock).not.toHaveBeenCalled();
+    expect(protectedRedirectMock).toHaveBeenCalledTimes(1);
+    expect(protectedRedirectMock).toHaveBeenCalledWith(session);
+  });
+
+  test('protected route reuses explicit signed-out root session context', async () => {
+    const protectedRedirect = redirect({ to: '/login' });
+
+    protectedRedirectMock.mockRejectedValueOnce(protectedRedirect);
+
+    await expect(
+      ProtectedRoute.options.beforeLoad?.({
+        context: { session: null }
+      } as never)
+    ).rejects.toBe(protectedRedirect);
+    expect(protectedRedirectMock).toHaveBeenCalledTimes(1);
+    expect(protectedRedirectMock).toHaveBeenCalledWith(null);
   });
 
   test('auth api route forwards GET requests to Better Auth handler', async () => {

--- a/test/routes/auth-routes.test.tsx
+++ b/test/routes/auth-routes.test.tsx
@@ -144,6 +144,7 @@ describe('auth routes', () => {
     });
 
     expect(loginRedirectMock).toHaveBeenCalledTimes(1);
+    expect(loginRedirectMock.mock.calls[0]).toEqual([]);
   });
 
   test('login route reuses root session context for redirect checks', async () => {
@@ -170,6 +171,26 @@ describe('auth routes', () => {
     ];
 
     await expect(routeAuthSessionPromise).resolves.toBe(session);
+  });
+
+  test('login route preserves explicit signed-out root session context', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ google: true }), {
+        headers: { 'content-type': 'application/json' },
+        status: 200
+      })
+    );
+
+    await LoginRoute.options.beforeLoad?.({
+      context: { session: null }
+    } as never);
+
+    expect(loginRedirectMock).toHaveBeenCalledTimes(1);
+    const [routeAuthSessionPromise] = loginRedirectMock.mock.calls[0] as unknown as [
+      Promise<unknown>
+    ];
+
+    await expect(routeAuthSessionPromise).resolves.toBeNull();
   });
 
   test('login route rejects with a real redirect for authenticated users', async () => {

--- a/test/routes/root-not-found.browser.test.tsx
+++ b/test/routes/root-not-found.browser.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import type { ReactNode } from 'react';
+
+import { RootNotFoundComponent, Route as RootRoute } from '@/routes/__root';
+import { TestI18nProvider } from '@/test-support/TestI18nProvider';
+
+const { navigateMock, signOutMock, updateUserMock } = vi.hoisted(() => ({
+  signOutMock: vi.fn<() => Promise<{ error?: { message?: string } | null } | void>>(),
+  navigateMock: vi.fn<(options: { to: string }) => Promise<void>>(),
+  updateUserMock:
+    vi.fn<(data: { locale: string }) => Promise<{ error?: { message?: string } | null }>>()
+}));
+
+vi.mock('@tanstack/react-router', async () => {
+  const actual =
+    await vi.importActual<typeof import('@tanstack/react-router')>('@tanstack/react-router');
+
+  return {
+    ...actual,
+    Link: ({ children, to, ...props }: { children: ReactNode; to: string }) => (
+      <a href={to} {...props}>
+        {children}
+      </a>
+    ),
+    useNavigate: () => navigateMock
+  };
+});
+
+vi.mock('@/features/auth/lib/auth-client', () => ({
+  getBrowserAuthClient: () => ({
+    signOut: signOutMock
+  }),
+  updateBrowserUserLocale: updateUserMock
+}));
+
+describe('RootNotFoundComponent', () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    signOutMock.mockReset();
+    updateUserMock.mockReset();
+    window.localStorage.clear();
+    document.documentElement.lang = 'en';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('renders standalone localized 404 for signed-out sessions', async () => {
+    window.localStorage.setItem('favoritable-locale', 'es');
+    vi.spyOn(RootRoute, 'useRouteContext').mockReturnValue({ session: null } as never);
+
+    render(
+      <TestI18nProvider>
+        <RootNotFoundComponent />
+      </TestI18nProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { level: 1, name: 'Página no encontrada' })).toBeDefined();
+    });
+
+    expect(screen.getByText('Favoritable')).toBeDefined();
+    expect(screen.getByRole('combobox', { name: 'Idioma' })).toBeDefined();
+    expect(screen.getByRole('link', { name: 'Ir al acceso' })).toHaveAttribute('href', '/login');
+    expect(screen.queryByText('Protected shell with Better Auth session')).toBeNull();
+  });
+
+  test('renders protected-shell 404 for signed-in sessions', async () => {
+    vi.spyOn(RootRoute, 'useRouteContext').mockReturnValue({
+      session: {
+        user: {
+          email: 'hello@favoritable.app',
+          locale: 'en',
+          name: 'Thiago'
+        }
+      }
+    } as never);
+    updateUserMock.mockResolvedValue({ error: null });
+
+    render(
+      <TestI18nProvider isAuthenticated serverLocale="en">
+        <RootNotFoundComponent />
+      </TestI18nProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { level: 2, name: 'Page not found' })).toBeDefined();
+    });
+
+    expect(screen.getByText('Protected shell with Better Auth session')).toBeDefined();
+    expect(screen.getByText('Thiago · hello@favoritable.app')).toBeDefined();
+    expect(screen.getByRole('link', { name: 'Go home' })).toHaveAttribute('href', '/');
+  });
+});

--- a/test/routes/root-not-found.browser.test.tsx
+++ b/test/routes/root-not-found.browser.test.tsx
@@ -61,6 +61,8 @@ describe('RootNotFoundComponent', () => {
       expect(screen.getByRole('heading', { level: 1, name: 'Página no encontrada' })).toBeDefined();
     });
 
+    expect(screen.getAllByRole('main')).toHaveLength(1);
+    expect(screen.getAllByRole('region', { name: 'Página no encontrada' })).toHaveLength(1);
     expect(screen.getByText('Favoritable')).toBeDefined();
     expect(screen.getByRole('combobox', { name: 'Idioma' })).toBeDefined();
     expect(screen.getByRole('link', { name: 'Ir al acceso' })).toHaveAttribute('href', '/login');

--- a/test/routes/root-not-found.browser.test.tsx
+++ b/test/routes/root-not-found.browser.test.tsx
@@ -3,13 +3,13 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import type { ReactNode } from 'react';
 
 import { RootNotFoundComponent, Route as RootRoute } from '@/routes/__root';
+import type { Locale } from '@/shared/i18n/locale';
 import { TestI18nProvider } from '@/test-support/TestI18nProvider';
 
 const { navigateMock, signOutMock, updateUserMock } = vi.hoisted(() => ({
   signOutMock: vi.fn<() => Promise<{ error?: { message?: string } | null } | void>>(),
   navigateMock: vi.fn<(options: { to: string }) => Promise<void>>(),
-  updateUserMock:
-    vi.fn<(data: { locale: string }) => Promise<{ error?: { message?: string } | null }>>()
+  updateUserMock: vi.fn<(locale: Locale) => Promise<{ error?: { message?: string } | null }>>()
 }));
 
 vi.mock('@tanstack/react-router', async () => {

--- a/test/routes/root.test.ts
+++ b/test/routes/root.test.ts
@@ -1,13 +1,26 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { createElement, type ReactElement, type ReactNode } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { routeAuthErrorMessage } from '@/features/auth/routes/route-auth';
-import { loadOptionalRouteSession } from '@/routes/__root';
+import { Route as RootRoute, loadOptionalRouteSession } from '@/routes/__root';
 
 const { appLoggerErrorMock, appLoggerWarnMock, getRouteAuthSessionMock } = vi.hoisted(() => ({
   appLoggerErrorMock: vi.fn<(message: string, context?: Record<string, unknown>) => void>(),
   appLoggerWarnMock: vi.fn<(message: string, context?: Record<string, unknown>) => void>(),
   getRouteAuthSessionMock: vi.fn<() => Promise<unknown>>()
 }));
+
+vi.mock('@tanstack/react-router', async () => {
+  const actual =
+    await vi.importActual<typeof import('@tanstack/react-router')>('@tanstack/react-router');
+
+  return {
+    ...actual,
+    HeadContent: () => null,
+    Scripts: () => null
+  };
+});
 
 vi.mock('@/features/auth/routes/route-auth', () => ({
   getRouteAuthSession: getRouteAuthSessionMock,
@@ -22,6 +35,10 @@ vi.mock('@/shared/logging/logger', () => ({
 }));
 
 describe('root route optional session loader', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   beforeEach(() => {
     appLoggerErrorMock.mockReset();
     appLoggerWarnMock.mockReset();
@@ -58,5 +75,73 @@ describe('root route optional session loader', () => {
       '[auth] Unexpected optional Better Auth session load failure.',
       { error }
     );
+  });
+
+  test('root route beforeLoad returns session context payload', async () => {
+    const session = { user: { id: 'user-2' } };
+
+    getRouteAuthSessionMock.mockResolvedValue(session);
+
+    await expect(RootRoute.options.beforeLoad?.({} as never)).resolves.toEqual({ session });
+  });
+
+  test('root route head includes app metadata and stylesheet link', () => {
+    expect(RootRoute.options.head?.({} as never)).toEqual({
+      links: [
+        {
+          href: expect.any(String),
+          rel: 'stylesheet'
+        }
+      ],
+      meta: [
+        {
+          charSet: 'utf-8'
+        },
+        {
+          content: 'width=device-width, initial-scale=1',
+          name: 'viewport'
+        },
+        {
+          title: 'Favoritable'
+        }
+      ]
+    });
+  });
+
+  test('root shell locks authenticated locale and normalizes lang attribute', () => {
+    vi.spyOn(RootRoute, 'useRouteContext').mockReturnValue({
+      session: {
+        user: {
+          email: 'hello@favoritable.app',
+          locale: 'es',
+          name: 'Thiago'
+        }
+      }
+    } as never);
+
+    const { shellComponent } = RootRoute.options as unknown as {
+      shellComponent: (props: { children: ReactNode }) => ReactElement;
+    };
+    const markup = renderToStaticMarkup(
+      shellComponent({ children: createElement('main', null, 'app') })
+    );
+
+    expect(markup).toContain('data-locale-locked="true"');
+    expect(markup).toContain('lang="es"');
+    expect(markup).toContain('<main>app</main>');
+  });
+
+  test('root shell uses default locale when no session exists', () => {
+    vi.spyOn(RootRoute, 'useRouteContext').mockReturnValue({ session: null } as never);
+
+    const { shellComponent } = RootRoute.options as unknown as {
+      shellComponent: (props: { children: ReactNode }) => ReactElement;
+    };
+    const markup = renderToStaticMarkup(
+      shellComponent({ children: createElement('main', null, 'app') })
+    );
+
+    expect(markup).toContain('lang="en"');
+    expect(markup).not.toContain('data-locale-locked');
   });
 });

--- a/test/routes/root.test.ts
+++ b/test/routes/root.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { routeAuthErrorMessage } from '@/features/auth/routes/route-auth';
+import { loadOptionalRouteSession } from '@/routes/__root';
+
+const { appLoggerErrorMock, appLoggerWarnMock, getRouteAuthSessionMock } = vi.hoisted(() => ({
+  appLoggerErrorMock: vi.fn<(message: string, context?: Record<string, unknown>) => void>(),
+  appLoggerWarnMock: vi.fn<(message: string, context?: Record<string, unknown>) => void>(),
+  getRouteAuthSessionMock: vi.fn<() => Promise<unknown>>()
+}));
+
+vi.mock('@/features/auth/routes/route-auth', () => ({
+  getRouteAuthSession: getRouteAuthSessionMock,
+  routeAuthErrorMessage: 'Failed to load Better Auth session.'
+}));
+
+vi.mock('@/shared/logging/logger', () => ({
+  appLogger: {
+    error: appLoggerErrorMock,
+    warn: appLoggerWarnMock
+  }
+}));
+
+describe('root route optional session loader', () => {
+  beforeEach(() => {
+    appLoggerErrorMock.mockReset();
+    appLoggerWarnMock.mockReset();
+    getRouteAuthSessionMock.mockReset();
+  });
+
+  test('returns session when auth session load succeeds', async () => {
+    const session = { user: { id: 'user-1' } };
+
+    getRouteAuthSessionMock.mockResolvedValue(session);
+
+    await expect(loadOptionalRouteSession()).resolves.toBe(session);
+  });
+
+  test('degrades to signed-out state for expected auth session load failures', async () => {
+    getRouteAuthSessionMock.mockRejectedValue(new Error(routeAuthErrorMessage));
+
+    await expect(loadOptionalRouteSession()).resolves.toBeNull();
+
+    expect(appLoggerWarnMock).toHaveBeenCalledWith(
+      '[auth] Optional Better Auth session load failed. Rendering signed-out fallback.'
+    );
+    expect(appLoggerErrorMock).not.toHaveBeenCalled();
+  });
+
+  test('logs unexpected auth session failures before rendering signed-out fallback', async () => {
+    const error = new Error('session failed');
+
+    getRouteAuthSessionMock.mockRejectedValue(error);
+
+    await expect(loadOptionalRouteSession()).resolves.toBeNull();
+
+    expect(appLoggerErrorMock).toHaveBeenCalledWith(
+      '[auth] Unexpected optional Better Auth session load failure.',
+      { error }
+    );
+  });
+});

--- a/test/shared/i18n/LanguageSwitcher.browser.test.tsx
+++ b/test/shared/i18n/LanguageSwitcher.browser.test.tsx
@@ -1,0 +1,102 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { LanguageSwitcher } from '@/shared/i18n/components/LanguageSwitcher';
+import { TestI18nProvider } from '@/test-support/TestI18nProvider';
+
+const { selectState } = vi.hoisted(() => ({
+  selectState: {
+    onValueChange: undefined as ((value: string | null) => void) | undefined,
+    renderedValue: null as unknown
+  }
+}));
+
+vi.mock('@base-ui/react/select', () => ({
+  Select: {
+    Root: ({
+      children,
+      onValueChange
+    }: {
+      children: ReactNode;
+      onValueChange?: (value: string | null) => void;
+    }) => {
+      selectState.onValueChange = onValueChange;
+      return <div>{children}</div>;
+    },
+    Trigger: ({ children, ...props }: { children: ReactNode }) => (
+      <button {...props} role="combobox" type="button">
+        {children}
+      </button>
+    ),
+    Value: ({ children }: { children: (value: unknown) => ReactNode }) => (
+      <>{children(selectState.renderedValue)}</>
+    ),
+    Portal: ({ children }: { children: ReactNode }) => <>{children}</>,
+    Positioner: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    Popup: ({ children, ...props }: { children: ReactNode }) => <div {...props}>{children}</div>,
+    List: ({ children, ...props }: { children: ReactNode }) => <div {...props}>{children}</div>,
+    Item: ({ children, value, ...props }: { children: ReactNode; value: string }) => (
+      <button {...props} onClick={() => selectState.onValueChange?.(value)} type="button">
+        {children}
+      </button>
+    ),
+    ItemIndicator: ({ children, ...props }: { children: ReactNode }) => (
+      <span {...props}>{children}</span>
+    ),
+    ItemText: ({ children, ...props }: { children: ReactNode }) => (
+      <span {...props}>{children}</span>
+    )
+  }
+}));
+
+describe('LanguageSwitcher', () => {
+  beforeEach(() => {
+    selectState.onValueChange = undefined;
+    selectState.renderedValue = null;
+  });
+
+  test('ignores null, invalid, and unchanged locale selections', () => {
+    const onLocaleChange = vi.fn<(locale: 'en' | 'es' | 'pt-BR') => void>();
+
+    render(
+      <TestI18nProvider>
+        <LanguageSwitcher hideLabel locale="en" onLocaleChange={onLocaleChange} />
+      </TestI18nProvider>
+    );
+
+    expect(screen.getByRole('combobox', { name: 'Language' })).toBeDefined();
+
+    selectState.onValueChange?.(null);
+    selectState.onValueChange?.('fr');
+    selectState.onValueChange?.('en');
+
+    expect(onLocaleChange).not.toHaveBeenCalled();
+  });
+
+  test('calls locale change handler when user picks a different supported locale', () => {
+    const onLocaleChange = vi.fn<(locale: 'en' | 'es' | 'pt-BR') => void>();
+
+    render(
+      <TestI18nProvider>
+        <LanguageSwitcher locale="en" onLocaleChange={onLocaleChange} />
+      </TestI18nProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Español ✓' }));
+
+    expect(onLocaleChange).toHaveBeenCalledWith('es');
+  });
+
+  test('falls back to current locale when select render value is invalid', () => {
+    selectState.renderedValue = 'fr';
+
+    render(
+      <TestI18nProvider>
+        <LanguageSwitcher locale="pt-BR" onLocaleChange={vi.fn()} />
+      </TestI18nProvider>
+    );
+
+    expect(screen.getByRole('combobox', { name: 'Language' })).toHaveTextContent('Português');
+  });
+});

--- a/test/shared/i18n/LanguageSwitcher.browser.test.tsx
+++ b/test/shared/i18n/LanguageSwitcher.browser.test.tsx
@@ -24,11 +24,7 @@ vi.mock('@base-ui/react/select', () => ({
       selectState.onValueChange = onValueChange;
       return <div>{children}</div>;
     },
-    Trigger: ({ children, ...props }: { children: ReactNode }) => (
-      <button {...props} role="combobox" type="button">
-        {children}
-      </button>
-    ),
+    Trigger: ({ children, ...props }: { children: ReactNode }) => <div {...props}>{children}</div>,
     Value: ({ children }: { children: (value: unknown) => ReactNode }) => (
       <>{children(selectState.renderedValue)}</>
     ),
@@ -65,7 +61,7 @@ describe('LanguageSwitcher', () => {
       </TestI18nProvider>
     );
 
-    expect(screen.getByRole('combobox', { name: 'Language' })).toBeDefined();
+    expect(screen.getByText('Language')).toBeDefined();
 
     selectState.onValueChange?.(null);
     selectState.onValueChange?.('fr');
@@ -93,10 +89,13 @@ describe('LanguageSwitcher', () => {
 
     render(
       <TestI18nProvider>
-        <LanguageSwitcher locale="pt-BR" onLocaleChange={vi.fn()} />
+        <LanguageSwitcher
+          locale="pt-BR"
+          onLocaleChange={vi.fn<(locale: 'en' | 'es' | 'pt-BR') => void>()}
+        />
       </TestI18nProvider>
     );
 
-    expect(screen.getByRole('combobox', { name: 'Language' })).toHaveTextContent('Português');
+    expect(screen.getByText('Language').parentElement).toHaveTextContent('Português');
   });
 });

--- a/test/shared/i18n/LocaleProvider.browser.test.tsx
+++ b/test/shared/i18n/LocaleProvider.browser.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { useLocale } from '@/shared/i18n/LocaleProvider';
 import { TestI18nProvider } from '@/test-support/TestI18nProvider';
@@ -29,6 +29,10 @@ function LocaleHarness() {
 }
 
 describe('LocaleProvider', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   beforeEach(() => {
     updateUserMock.mockReset();
     window.localStorage.clear();
@@ -48,6 +52,26 @@ describe('LocaleProvider', () => {
     await waitFor(() => {
       expect(screen.getByTestId('locale-value')).toHaveTextContent('pt-BR');
       expect(document.documentElement.lang).toBe('pt-BR');
+    });
+  });
+
+  test('falls back to default locale for signed-out tests when no locale is preset', async () => {
+    document.documentElement.lang = '';
+    vi.stubGlobal('navigator', {
+      language: 'es-AR',
+      languages: ['es-AR']
+    });
+
+    render(
+      <TestI18nProvider>
+        <LocaleHarness />
+      </TestI18nProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('locale-value')).toHaveTextContent('en');
+      expect(document.documentElement.lang).toBe('en');
+      expect(window.localStorage.getItem('favoritable-locale')).toBe('en');
     });
   });
 

--- a/test/shared/i18n/LocaleProvider.browser.test.tsx
+++ b/test/shared/i18n/LocaleProvider.browser.test.tsx
@@ -2,11 +2,11 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { useLocale } from '@/shared/i18n/LocaleProvider';
+import type { Locale } from '@/shared/i18n/locale';
 import { TestI18nProvider } from '@/test-support/TestI18nProvider';
 
 const { updateUserMock } = vi.hoisted(() => ({
-  updateUserMock:
-    vi.fn<(data: { locale: string }) => Promise<{ error?: { message?: string } | null }>>()
+  updateUserMock: vi.fn<(locale: Locale) => Promise<{ error?: { message?: string } | null }>>()
 }));
 
 vi.mock('@/features/auth/lib/auth-client', () => ({

--- a/test/shared/i18n/LocaleProvider.browser.test.tsx
+++ b/test/shared/i18n/LocaleProvider.browser.test.tsx
@@ -1,0 +1,111 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { useLocale } from '@/shared/i18n/LocaleProvider';
+import { TestI18nProvider } from '@/test-support/TestI18nProvider';
+
+const { updateUserMock } = vi.hoisted(() => ({
+  updateUserMock:
+    vi.fn<(data: { locale: string }) => Promise<{ error?: { message?: string } | null }>>()
+}));
+
+vi.mock('@/features/auth/lib/auth-client', () => ({
+  updateBrowserUserLocale: updateUserMock
+}));
+
+function LocaleHarness() {
+  const { isUpdatingLocale, locale, localeUpdateError, setLocale } = useLocale();
+
+  return (
+    <div>
+      <span data-testid="locale-value">{locale}</span>
+      <span data-testid="locale-updating">{isUpdatingLocale ? 'yes' : 'no'}</span>
+      <span data-testid="locale-error">{localeUpdateError ? 'yes' : 'no'}</span>
+      <button onClick={() => void setLocale('es')} type="button">
+        Switch to Spanish
+      </button>
+    </div>
+  );
+}
+
+describe('LocaleProvider', () => {
+  beforeEach(() => {
+    updateUserMock.mockReset();
+    window.localStorage.clear();
+    document.documentElement.lang = 'en';
+    document.cookie = 'favoritable-locale-hint=; Max-Age=0; Path=/';
+  });
+
+  test('resolves signed-out locale from localStorage before browser defaults', async () => {
+    window.localStorage.setItem('favoritable-locale', 'pt-BR');
+
+    render(
+      <TestI18nProvider>
+        <LocaleHarness />
+      </TestI18nProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('locale-value')).toHaveTextContent('pt-BR');
+      expect(document.documentElement.lang).toBe('pt-BR');
+    });
+  });
+
+  test('overrides stale local storage with authenticated server locale immediately', async () => {
+    window.localStorage.setItem('favoritable-locale', 'pt-BR');
+    document.cookie = 'favoritable-locale-hint=pt-BR';
+
+    render(
+      <TestI18nProvider isAuthenticated serverLocale="es">
+        <LocaleHarness />
+      </TestI18nProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('locale-value')).toHaveTextContent('es');
+      expect(document.documentElement.lang).toBe('es');
+      expect(window.localStorage.getItem('favoritable-locale')).toBe('es');
+    });
+  });
+
+  test('persists authenticated locale updates optimistically', async () => {
+    updateUserMock.mockResolvedValue({ error: null });
+
+    render(
+      <TestI18nProvider isAuthenticated serverLocale="en">
+        <LocaleHarness />
+      </TestI18nProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Switch to Spanish' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('locale-value')).toHaveTextContent('es');
+      expect(updateUserMock).toHaveBeenCalledWith('es');
+      expect(window.localStorage.getItem('favoritable-locale')).toBe('es');
+      expect(screen.getByTestId('locale-error')).toHaveTextContent('no');
+    });
+  });
+
+  test('rolls back failed authenticated locale updates', async () => {
+    updateUserMock.mockResolvedValue({
+      error: {
+        message: 'nope'
+      }
+    });
+
+    render(
+      <TestI18nProvider isAuthenticated serverLocale="en">
+        <LocaleHarness />
+      </TestI18nProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Switch to Spanish' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('locale-value')).toHaveTextContent('en');
+      expect(document.documentElement.lang).toBe('en');
+      expect(screen.getByTestId('locale-error')).toHaveTextContent('yes');
+    });
+  });
+});

--- a/test/shared/i18n/LocaleProvider.browser.test.tsx
+++ b/test/shared/i18n/LocaleProvider.browser.test.tsx
@@ -13,6 +13,17 @@ vi.mock('@/features/auth/lib/auth-client', () => ({
   updateBrowserUserLocale: updateUserMock
 }));
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, reject, resolve };
+}
+
 function LocaleHarness() {
   const { isUpdatingLocale, locale, localeUpdateError, setLocale } = useLocale();
 
@@ -130,6 +141,48 @@ describe('LocaleProvider', () => {
       expect(screen.getByTestId('locale-value')).toHaveTextContent('en');
       expect(document.documentElement.lang).toBe('en');
       expect(screen.getByTestId('locale-error')).toHaveTextContent('yes');
+    });
+  });
+
+  test('rolls back to latest confirmed locale when server locale changes mid-request', async () => {
+    const deferredUpdate = createDeferred<{ error?: { message?: string } | null }>();
+    updateUserMock.mockReturnValue(deferredUpdate.promise);
+
+    const { rerender } = render(
+      <TestI18nProvider isAuthenticated serverLocale="en">
+        <LocaleHarness />
+      </TestI18nProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Switch to Spanish' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('locale-value')).toHaveTextContent('es');
+      expect(screen.getByTestId('locale-updating')).toHaveTextContent('yes');
+    });
+
+    rerender(
+      <TestI18nProvider isAuthenticated serverLocale="pt-BR">
+        <LocaleHarness />
+      </TestI18nProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('locale-value')).toHaveTextContent('pt-BR');
+      expect(document.documentElement.lang).toBe('pt-BR');
+    });
+
+    deferredUpdate.resolve({
+      error: {
+        message: 'nope'
+      }
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('locale-value')).toHaveTextContent('pt-BR');
+      expect(document.documentElement.lang).toBe('pt-BR');
+      expect(screen.getByTestId('locale-error')).toHaveTextContent('yes');
+      expect(screen.getByTestId('locale-updating')).toHaveTextContent('no');
     });
   });
 });

--- a/test/shared/i18n/locale.test.ts
+++ b/test/shared/i18n/locale.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import {
   applyDocumentLocale,
+  clearLocaleHintCookie,
   defaultLocale,
   getBrowserLocale,
   getLocaleHintFromCookieHeader,
@@ -9,7 +10,8 @@ import {
   isLocale,
   localeBootstrapScript,
   mapBrowserLanguageToLocale,
-  resolveClientLocale
+  resolveClientLocale,
+  setLocaleHintCookie
 } from '@/shared/i18n/locale';
 
 afterEach(() => {
@@ -80,6 +82,21 @@ describe('locale helpers', () => {
     expect(document.documentElement.lang).toBe('es');
     expect(getLocaleHintFromCookieHeader('favoritable-locale-hint=es')).toBe('es');
     expect(getLocaleHintFromCookieHeader('favoritable-locale-hint=fr-FR')).toBeNull();
+  });
+
+  test('uses secure locale hint cookies on https and mirrors that on clear', () => {
+    stubDocument();
+    vi.stubGlobal('location', {
+      protocol: 'https:'
+    });
+
+    setLocaleHintCookie('pt-BR');
+    expect(document.cookie).toContain('favoritable-locale-hint=pt-BR');
+    expect(document.cookie).toContain('Secure');
+
+    clearLocaleHintCookie();
+    expect(document.cookie).toContain('favoritable-locale-hint=; Max-Age=0');
+    expect(document.cookie).toContain('Secure');
   });
 
   test('keeps bootstrap logic english-safe and auth-lock aware', () => {

--- a/test/shared/i18n/locale.test.ts
+++ b/test/shared/i18n/locale.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import {
+  applyDocumentLocale,
+  defaultLocale,
+  getBrowserLocale,
+  getLocaleHintFromCookieHeader,
+  getStoredLocale,
+  isLocale,
+  localeBootstrapScript,
+  mapBrowserLanguageToLocale,
+  resolveClientLocale
+} from '@/shared/i18n/locale';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function stubWindow(storedLocale: string | null) {
+  vi.stubGlobal('window', {
+    localStorage: {
+      getItem: vi.fn<(key: string) => string | null>((key) =>
+        key === 'favoritable-locale' ? storedLocale : null
+      )
+    }
+  });
+}
+
+function stubDocument() {
+  vi.stubGlobal('document', {
+    documentElement: {
+      dataset: {},
+      lang: '',
+      style: {}
+    }
+  });
+}
+
+describe('locale helpers', () => {
+  test('accepts only supported locale values', () => {
+    expect(isLocale('en')).toBe(true);
+    expect(isLocale('pt-BR')).toBe(true);
+    expect(isLocale('es')).toBe(true);
+    expect(isLocale('pt-PT')).toBe(false);
+    expect(isLocale(undefined)).toBe(false);
+  });
+
+  test('maps browser base languages to supported locales', () => {
+    expect(mapBrowserLanguageToLocale('pt-PT')).toBe('pt-BR');
+    expect(mapBrowserLanguageToLocale('es-MX')).toBe('es');
+    expect(mapBrowserLanguageToLocale('en-GB')).toBe('en');
+    expect(mapBrowserLanguageToLocale('fr-FR')).toBe(defaultLocale);
+  });
+
+  test('uses the browser language list when available', () => {
+    vi.stubGlobal('navigator', {
+      language: 'en-US',
+      languages: ['es-AR', 'en-US']
+    });
+
+    expect(getBrowserLocale()).toBe('es');
+  });
+
+  test('ignores invalid stored locale values and falls back safely', () => {
+    stubWindow('fr-FR');
+    vi.stubGlobal('navigator', {
+      language: 'pt-PT',
+      languages: ['pt-PT']
+    });
+
+    expect(getStoredLocale()).toBeNull();
+    expect(resolveClientLocale()).toBe('pt-BR');
+  });
+
+  test('applies locale to document safely and reads locale hint cookies', () => {
+    stubDocument();
+
+    applyDocumentLocale('es');
+
+    expect(document.documentElement.lang).toBe('es');
+    expect(getLocaleHintFromCookieHeader('favoritable-locale-hint=es')).toBe('es');
+    expect(getLocaleHintFromCookieHeader('favoritable-locale-hint=fr-FR')).toBeNull();
+  });
+
+  test('keeps bootstrap logic english-safe and auth-lock aware', () => {
+    expect(localeBootstrapScript).toContain("root.dataset.localeLocked === 'true'");
+    expect(localeBootstrapScript).toContain('window.localStorage.getItem(storageKey)');
+    expect(localeBootstrapScript).toContain(
+      'navigator.languages?.find(Boolean) || navigator.language'
+    );
+  });
+});

--- a/test/shared/logging/logger.test.ts
+++ b/test/shared/logging/logger.test.ts
@@ -1,43 +1,86 @@
-import { afterEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { appLogger } from '@/shared/logging/logger';
+type PinoLogMethod = (contextOrMessage: unknown, message?: string) => void;
+type PinoLogger = {
+  error: PinoLogMethod;
+  warn: PinoLogMethod;
+};
+
+const { pinoErrorMock, pinoMock, pinoWarnMock } = vi.hoisted(() => {
+  const hoistedPinoErrorMock = vi.fn<PinoLogMethod>();
+  const hoistedPinoWarnMock = vi.fn<PinoLogMethod>();
+  const hoistedPinoMock = vi.fn<() => PinoLogger>(() => ({
+    error: hoistedPinoErrorMock,
+    warn: hoistedPinoWarnMock
+  }));
+
+  return {
+    pinoErrorMock: hoistedPinoErrorMock,
+    pinoMock: hoistedPinoMock,
+    pinoWarnMock: hoistedPinoWarnMock
+  };
+});
+
+vi.mock('pino', () => ({
+  default: pinoMock
+}));
 
 describe('appLogger', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    pinoMock.mockClear();
+    pinoWarnMock.mockClear();
+    pinoErrorMock.mockClear();
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  test('writes warn logs without context', () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  test('creates pino logger with app-safe config', async () => {
+    await import('@/shared/logging/logger');
+
+    expect(pinoMock).toHaveBeenCalledWith({
+      base: undefined,
+      browser: {
+        asObject: true
+      },
+      level: 'silent',
+      name: 'favoritable'
+    });
+  });
+
+  test('writes warn logs without context', async () => {
+    const { appLogger } = await import('@/shared/logging/logger');
 
     appLogger.warn('warn message');
 
-    expect(warnSpy).toHaveBeenCalledWith('warn message');
+    expect(pinoWarnMock).toHaveBeenCalledWith('warn message');
   });
 
-  test('writes warn logs with context', () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  test('writes warn logs with context', async () => {
+    const { appLogger } = await import('@/shared/logging/logger');
     const context = { feature: 'i18n' };
 
     appLogger.warn('warn message', context);
 
-    expect(warnSpy).toHaveBeenCalledWith('warn message', context);
+    expect(pinoWarnMock).toHaveBeenCalledWith(context, 'warn message');
   });
 
-  test('writes error logs without context', () => {
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  test('writes error logs without context', async () => {
+    const { appLogger } = await import('@/shared/logging/logger');
 
     appLogger.error('error message');
 
-    expect(errorSpy).toHaveBeenCalledWith('error message');
+    expect(pinoErrorMock).toHaveBeenCalledWith('error message');
   });
 
-  test('writes error logs with context', () => {
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  test('writes error logs with context', async () => {
+    const { appLogger } = await import('@/shared/logging/logger');
     const context = { error: new Error('boom') };
 
     appLogger.error('error message', context);
 
-    expect(errorSpy).toHaveBeenCalledWith('error message', context);
+    expect(pinoErrorMock).toHaveBeenCalledWith(context, 'error message');
   });
 });

--- a/test/shared/logging/logger.test.ts
+++ b/test/shared/logging/logger.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { appLogger } from '@/shared/logging/logger';
+
+describe('appLogger', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('writes warn logs without context', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    appLogger.warn('warn message');
+
+    expect(warnSpy).toHaveBeenCalledWith('warn message');
+  });
+
+  test('writes warn logs with context', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const context = { feature: 'i18n' };
+
+    appLogger.warn('warn message', context);
+
+    expect(warnSpy).toHaveBeenCalledWith('warn message', context);
+  });
+
+  test('writes error logs without context', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    appLogger.error('error message');
+
+    expect(errorSpy).toHaveBeenCalledWith('error message');
+  });
+
+  test('writes error logs with context', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const context = { error: new Error('boom') };
+
+    appLogger.error('error message', context);
+
+    expect(errorSpy).toHaveBeenCalledWith('error message', context);
+  });
+});

--- a/test/shared/theme/ThemeToggle.browser.test.tsx
+++ b/test/shared/theme/ThemeToggle.browser.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import { TestI18nProvider } from '@/test-support/TestI18nProvider';
 import { ThemeProvider } from '@/shared/theme/ThemeProvider';
 import { ThemeToggle } from '@/shared/theme/ThemeToggle';
 
@@ -62,9 +63,11 @@ describe('ThemeToggle', () => {
     vi.stubGlobal('matchMedia', vi.fn().mockReturnValue(mediaQueryList));
 
     render(
-      <ThemeProvider>
-        <ThemeToggle />
-      </ThemeProvider>
+      <TestI18nProvider>
+        <ThemeProvider>
+          <ThemeToggle />
+        </ThemeProvider>
+      </TestI18nProvider>
     );
 
     const switchControl = screen.getByRole('switch', { name: 'Dark mode' });
@@ -90,9 +93,11 @@ describe('ThemeToggle', () => {
     vi.stubGlobal('matchMedia', vi.fn().mockReturnValue(mediaQueryList));
 
     render(
-      <ThemeProvider>
-        <ThemeToggle />
-      </ThemeProvider>
+      <TestI18nProvider>
+        <ThemeProvider>
+          <ThemeToggle />
+        </ThemeProvider>
+      </TestI18nProvider>
     );
 
     await waitFor(() => {
@@ -115,9 +120,11 @@ describe('ThemeToggle', () => {
     window.localStorage.setItem('favoritable-theme', 'dark');
 
     render(
-      <ThemeProvider>
-        <ThemeToggle />
-      </ThemeProvider>
+      <TestI18nProvider>
+        <ThemeProvider>
+          <ThemeToggle />
+        </ThemeProvider>
+      </TestI18nProvider>
     );
 
     const switchControl = screen.getByRole('switch', { name: 'Dark mode' });

--- a/test/test-support/TestI18nProvider.browser.test.tsx
+++ b/test/test-support/TestI18nProvider.browser.test.tsx
@@ -1,5 +1,5 @@
 import { renderToStaticMarkup } from 'react-dom/server';
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { TestI18nProvider } from '@/test-support/TestI18nProvider';
 
@@ -11,6 +11,11 @@ describe('TestI18nProvider', () => {
       language: 'es-AR',
       languages: ['es-AR']
     });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   test('does not mutate locale storage or document lang during render', () => {

--- a/test/test-support/TestI18nProvider.browser.test.tsx
+++ b/test/test-support/TestI18nProvider.browser.test.tsx
@@ -1,0 +1,29 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { TestI18nProvider } from '@/test-support/TestI18nProvider';
+
+describe('TestI18nProvider', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    document.documentElement.lang = '';
+    vi.stubGlobal('navigator', {
+      language: 'es-AR',
+      languages: ['es-AR']
+    });
+  });
+
+  test('does not mutate locale storage or document lang during render', () => {
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem');
+
+    const markup = renderToStaticMarkup(
+      <TestI18nProvider>
+        <span>ready</span>
+      </TestI18nProvider>
+    );
+
+    expect(markup).toBe('');
+    expect(setItemSpy).not.toHaveBeenCalled();
+    expect(document.documentElement.lang).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

Introduces app-wide internationalization (i18n) with canonical locale persistence and a shell-aware, fully localized 404 (Not Found) experience. This bundles the FAV-25 epic deliverables: FAV-27 (app-wide i18n), FAV-26 (shell-aware localized 404), and the final selector polish plus public 404 login-shell layout refinement.

## What was added

### FAV-27 — App-wide i18n with canonical locale persistence
- New `src/shared/i18n` module: `LocaleProvider`, `i18n` setup, `locale` resolution utilities, and a `LanguageSwitcher` component.
- Resource catalogs for `en`, `es`, and `pt-BR` under `src/shared/i18n/resources`.
- Canonical locale persistence: selected locale is normalized to a canonical form and persisted (cookie/local storage) so SSR and client render stay in sync across reloads.
- `TestI18nProvider` added under `src/test-support` for deterministic locale in component tests.
- Wired i18n into the root shell so all user-facing strings are translatable.

### FAV-26 — Shell-aware localized 404
- `NotFoundContent` shared component plus two shell-aware views: `ProtectedNotFoundPage` (renders inside the authenticated app shell) and `PublicNotFoundPage` (renders inside the login/auth shell).
- `__root` and `_protected` routing updated so unmatched routes resolve to the contextually correct 404 (protected vs public).
- All 404 copy flows through the i18n resource catalogs.

### Final selector polish & public 404 login-shell layout refinement
- Login/auth shell layout refined (`LoginPage`, new `AuthPageHero`) and CSS module selectors polished across `ProfileMenu`, `ThemeToggle`, `ProviderButton`, and not-found styles for consistent design-token usage.

### Other
- `src/shared/logging/logger.ts` (Pino) introduced for shared logging.
- Auth schema/migration updates (`drizzle/0001_strange_medusa.sql`) supporting the i18n/locale data needs.
- Updated dependent unit/browser tests across app-shell, auth, theme, routes, and added new i18n + not-found test coverage.

## Testing & QA

- `complete-check` run: **PASS** (lint, typecheck, unit + browser tests, production build).
- New E2E smoke specs added: `locale-smoke.spec.ts`, `not-found-smoke.spec.ts`, `authenticated-not-found-smoke.spec.ts` (all `@smoke` happy paths).
- New unit/browser coverage for `LocaleProvider`, `locale` utilities, `NotFoundContent`, and root not-found routing.

## Notes

- No breaking API changes.
- Dependabot flagged 3 pre-existing vulnerabilities on the default branch (unrelated to this change).